### PR TITLE
Use current macOS wallpaper as background

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -293,6 +293,27 @@ pub async fn get_mouse_position() -> Result<(f64, f64), String> {
     Ok((x, y))
 }
 
+/// Get the current macOS wallpaper (desktop picture) path
+#[tauri::command]
+pub async fn get_current_wallpaper() -> Result<String, String> {
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg("tell application \"System Events\" to get picture of desktop 1")
+        .output()
+        .map_err(|e| format!("Failed to get wallpaper: {}", e))?;
+
+    if !output.status.success() {
+        return Err("Failed to get wallpaper".to_string());
+    }
+
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if path.is_empty() {
+        return Err("Wallpaper path is empty".to_string());
+    }
+
+    Ok(path)
+}
+
 /// Capture specific window using macOS native screencapture
 #[tauri::command]
 pub async fn native_capture_window(save_dir: String) -> Result<String, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod utils;
 use commands::{
     capture_all_monitors, capture_once, capture_region, get_desktop_directory, get_mouse_position,
     get_temp_directory, native_capture_fullscreen, native_capture_interactive,
+    get_current_wallpaper,
     native_capture_window, play_screenshot_sound, save_edited_image,
 };
 
@@ -112,7 +113,8 @@ pub fn run() {
             native_capture_fullscreen,
             native_capture_window,
             play_screenshot_sound,
-            get_mouse_position
+            get_mouse_position,
+            get_current_wallpaper
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,7 +34,11 @@
           "/private/tmp/**",
           "/var/**",
           "/private/var/**",
+          "/Library/Desktop Pictures/**",
+          "/System/Library/Desktop Pictures/**",
           "$HOME/Pictures/**",
+          "$HOME/Library/Application Support/com.apple.mobileAssetDesktop/**",
+          "$HOME/Library/Application Support/com.apple.wallpaper/**",
           "$PICTURES/**",
           "$TEMP/**",
           "$APPDATA/**"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
-import { migrateStoredValue, isAssetId, isDataUrl } from "@/lib/asset-registry";
+import { migrateStoredValue, isAssetId, isDataUrl, isSystemWallpaper } from "@/lib/asset-registry";
 import { processScreenshotWithDefaultBackground } from "@/lib/auto-process";
 import { hasCompletedOnboarding } from "@/lib/onboarding";
 import { invoke } from "@tauri-apps/api/core";
@@ -216,7 +216,12 @@ function App() {
 
         // Migrate legacy background image paths to asset IDs
         const savedBackgroundImage = await store.get<string>("defaultBackgroundImage");
-        if (savedBackgroundImage && !isAssetId(savedBackgroundImage) && !isDataUrl(savedBackgroundImage)) {
+        if (
+          savedBackgroundImage &&
+          !isAssetId(savedBackgroundImage) &&
+          !isDataUrl(savedBackgroundImage) &&
+          !isSystemWallpaper(savedBackgroundImage)
+        ) {
           // This is a legacy path that needs migration
           const migratedValue = migrateStoredValue(savedBackgroundImage);
           if (migratedValue && migratedValue !== savedBackgroundImage) {

--- a/src/components/ImageEditor.tsx
+++ b/src/components/ImageEditor.tsx
@@ -16,6 +16,7 @@ import { PropertiesPanel } from "./editor/PropertiesPanel";
 import { Annotation, ToolType } from "@/types/annotations";
 import { usePreviewGenerator } from "@/hooks/usePreviewGenerator";
 import { assetCategories } from "@/hooks/useEditorSettings";
+import { getSystemWallpaperSrc } from "@/lib/asset-registry";
 import {
   useSettings,
   useAnnotations,
@@ -43,6 +44,7 @@ export function ImageEditor({ imagePath, onSave, onCancel }: ImageEditorProps) {
   const [screenshotImage, setScreenshotImage] = useState<HTMLImageElement | null>(null);
   const [imageLoaded, setImageLoaded] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [systemWallpaperSrc, setSystemWallpaperSrc] = useState<string | null>(null);
   
   // Save/copy state
   const [isSaving, setIsSaving] = useState(false);
@@ -91,6 +93,20 @@ export function ImageEditor({ imagePath, onSave, onCancel }: ImageEditorProps) {
     invoke<string>("get_temp_directory")
       .then((dir) => setTempDir(dir))
       .catch((err) => console.error("Failed to get temp directory:", err));
+  }, []);
+
+  useEffect(() => {
+    let isActive = true;
+    const loadSystemWallpaper = async () => {
+      const wallpaperSrc = await getSystemWallpaperSrc();
+      if (isActive) {
+        setSystemWallpaperSrc(wallpaperSrc);
+      }
+    };
+    loadSystemWallpaper();
+    return () => {
+      isActive = false;
+    };
   }, []);
 
   // Load main screenshot image
@@ -425,6 +441,7 @@ export function ImageEditor({ imagePath, onSave, onCancel }: ImageEditorProps) {
                 categories={assetCategories}
                 selectedImage={settings.selectedImageSrc}
                 backgroundType={settings.backgroundType}
+                systemWallpaperSrc={systemWallpaperSrc}
                 onImageSelect={actions.handleImageSelect}
               />
 

--- a/src/components/editor/AssetGrid.tsx
+++ b/src/components/editor/AssetGrid.tsx
@@ -16,13 +16,23 @@ interface AssetGridProps {
   categories: AssetCategory[];
   selectedImage: string | null;
   backgroundType: string;
+  systemWallpaperSrc?: string | null;
   onImageSelect: (imageSrc: string) => void;
 }
 
-export const AssetGrid = memo(function AssetGrid({ categories, selectedImage, backgroundType, onImageSelect }: AssetGridProps) {
+export const AssetGrid = memo(function AssetGrid({ categories, selectedImage, backgroundType, systemWallpaperSrc, onImageSelect }: AssetGridProps) {
   const [activeCategory, setActiveCategory] = useState(categories[0]?.name || "");
 
   const currentCategory = categories.find((cat) => cat.name === activeCategory);
+  const showSystemWallpaper = currentCategory?.name === "Wallpapers" && !!systemWallpaperSrc;
+  const assetsToRender = currentCategory
+    ? [
+        ...(showSystemWallpaper
+          ? [{ id: "system-wallpaper", src: systemWallpaperSrc!, name: "Current Wallpaper" }]
+          : []),
+        ...currentCategory.assets,
+      ]
+    : [];
 
   return (
     <div className="space-y-4">
@@ -51,7 +61,7 @@ export const AssetGrid = memo(function AssetGrid({ categories, selectedImage, ba
       )}
 
       <div className="grid grid-cols-4 gap-2 max-h-[400px] overflow-y-auto pr-4 pb-2 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-zinc-700 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-transparent">
-        {currentCategory?.assets.map((asset) => (
+        {assetsToRender.map((asset) => (
           <button
             key={asset.id}
             onClick={() => onImageSelect(asset.src)}
@@ -68,6 +78,11 @@ export const AssetGrid = memo(function AssetGrid({ categories, selectedImage, ba
               alt={asset.name}
               className="w-full h-full object-cover transition-transform group-hover:scale-110"
             />
+            {asset.id === "system-wallpaper" && (
+              <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-[10px] text-white px-2 py-1 text-pretty">
+                Current wallpaper
+              </div>
+            )}
             {backgroundType === "image" && selectedImage === asset.src && (
               <div className="absolute inset-0 bg-blue-500/20 flex items-center justify-center">
                 <div className="size-6 rounded-full bg-blue-500 flex items-center justify-center shadow-lg">

--- a/src/hooks/useEditorSettings.ts
+++ b/src/hooks/useEditorSettings.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
 import { Store } from "@tauri-apps/plugin-store";
 import { gradientOptions, type GradientOption } from "@/components/editor/BackgroundSelector";
-import { resolveBackgroundPath, getDefaultBackgroundPath } from "@/lib/asset-registry";
+import { resolveBackgroundPathAsync, getDefaultBackgroundPath } from "@/lib/asset-registry";
 
 // Import all background images
 import bgImage13 from "@/assets/bg-images/asset-13.jpg";
@@ -124,8 +124,7 @@ export function useEditorSettings(): [EditorSettings, EditorSettingsActions] {
         const store = await Store.load("settings.json");
         const storedBg = await store.get<string>("defaultBackgroundImage");
         if (storedBg) {
-          // Resolve stored value (asset ID or data URL) to actual path
-          const resolvedPath = resolveBackgroundPath(storedBg);
+          const resolvedPath = await resolveBackgroundPathAsync(storedBg);
           setSelectedImageSrc(resolvedPath);
         }
       } catch (err) {

--- a/src/hooks/useEditorState.ts
+++ b/src/hooks/useEditorState.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { Store } from "@tauri-apps/plugin-store";
 import { gradientOptions, type GradientOption } from "@/components/editor/BackgroundSelector";
-import { resolveBackgroundPath, getDefaultBackgroundPath } from "@/lib/asset-registry";
+import { resolveBackgroundPathAsync, getDefaultBackgroundPath } from "@/lib/asset-registry";
 import { Annotation } from "@/types/annotations";
 
 export type BackgroundType = "transparent" | "white" | "black" | "gray" | "gradient" | "custom" | "image";
@@ -106,7 +106,7 @@ export function useEditorState(): EditorStateResult {
         const store = await Store.load("settings.json");
         const storedBg = await store.get<string>("defaultBackgroundImage");
         if (storedBg) {
-          const resolvedPath = resolveBackgroundPath(storedBg);
+          const resolvedPath = await resolveBackgroundPathAsync(storedBg);
           setState(prev => ({
             ...prev,
             settings: {

--- a/src/lib/auto-process.ts
+++ b/src/lib/auto-process.ts
@@ -1,7 +1,7 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { Store } from "@tauri-apps/plugin-store";
 import { createHighQualityCanvas } from "./canvas-utils";
-import { resolveBackgroundPath, getDefaultBackgroundPath } from "./asset-registry";
+import { resolveBackgroundPathAsync, getDefaultBackgroundPath } from "./asset-registry";
 
 export async function processScreenshotWithDefaultBackground(
   imagePath: string
@@ -9,13 +9,12 @@ export async function processScreenshotWithDefaultBackground(
   return new Promise(async (resolve, reject) => {
     // Get the default background path, resolving from store if available
     let defaultBgImage: string = getDefaultBackgroundPath();
-    
+
     try {
       const store = await Store.load("settings.json");
       const storedDefaultBg = await store.get<string>("defaultBackgroundImage");
       if (storedDefaultBg) {
-        // Resolve the stored value (asset ID or data URL) to actual path
-        defaultBgImage = resolveBackgroundPath(storedDefaultBg);
+        defaultBgImage = await resolveBackgroundPathAsync(storedDefaultBg);
       }
     } catch (err) {
       console.error("Failed to load default background from settings:", err);

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -3,7 +3,7 @@ import { subscribeWithSelector } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 import { Store } from "@tauri-apps/plugin-store";
 import { gradientOptions, type GradientOption } from "@/components/editor/BackgroundSelector";
-import { resolveBackgroundPath, getDefaultBackgroundPath } from "@/lib/asset-registry";
+import { resolveBackgroundPathAsync, getDefaultBackgroundPath } from "@/lib/asset-registry";
 import { Annotation } from "@/types/annotations";
 
 // ============================================================================
@@ -161,7 +161,7 @@ export const useEditorStore = create<EditorStore>()(
           const store = await Store.load("settings.json");
           const storedBg = await store.get<string>("defaultBackgroundImage");
           if (storedBg) {
-            const resolvedPath = resolveBackgroundPath(storedBg);
+            const resolvedPath = await resolveBackgroundPathAsync(storedBg);
             set((state) => {
               state.settings.selectedImageSrc = resolvedPath;
               state._isInitialized = true;


### PR DESCRIPTION
## Summary
- Add a system wallpaper option for default/editor backgrounds
- Resolve wallpaper path via Tauri command and allow wallpaper directories
- Load wallpaper asynchronously in settings and auto-apply flows

![Screenshot 2026-01-13 at 19 28 34](https://github.com/user-attachments/assets/f0473927-a8d4-49f5-a115-7441f487b9a9)

Fixes #8
