### PR TITLE
feat: Add blur annotation tool for sensitive content redaction

### DIFF
--- a/src/components/editor/AnnotationCanvas.tsx
+++ b/src/components/editor/AnnotationCanvas.tsx
@@ -182,6 +182,20 @@ export const AnnotationCanvas = memo(function AnnotationCanvas({
             alignment: defaultAlignment,
           };
         }
+        case "blur": {
+          return {
+            id: generateId(),
+            type: "blur",
+            x: Math.min(start.x, end.x),
+            y: Math.min(start.y, end.y),
+            width: Math.abs(end.x - start.x),
+            height: Math.abs(end.y - start.y),
+            blurAmount: 20,
+            fill: defaultColor,
+            border: defaultBorder,
+            alignment: defaultAlignment,
+          };
+        }
         default:
           return null;
       }
@@ -238,6 +252,14 @@ export const AnnotationCanvas = memo(function AnnotationCanvas({
         );
         return distance <= annotation.radius;
       }
+      case "blur": {
+        return (
+          point.x >= annotation.x &&
+          point.x <= annotation.x + annotation.width &&
+          point.y >= annotation.y &&
+          point.y <= annotation.y + annotation.height
+        );
+      }
       default:
         return false;
     }
@@ -283,6 +305,10 @@ export const AnnotationCanvas = memo(function AnnotationCanvas({
             ctx.beginPath();
             ctx.arc(annotation.x, annotation.y, annotation.radius + 5, 0, Math.PI * 2);
             ctx.stroke();
+            break;
+          }
+          case "blur": {
+            ctx.strokeRect(annotation.x - 5, annotation.y - 5, annotation.width + 10, annotation.height + 10);
             break;
           }
         }

--- a/src/components/editor/AnnotationToolbar.tsx
+++ b/src/components/editor/AnnotationToolbar.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { Circle, Square, Minus, ArrowUpRight, Type, Hash, MousePointer2, Trash2 } from "lucide-react";
+import { Circle, Square, Minus, ArrowUpRight, Type, Hash, MousePointer2, Trash2, Scan } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ToolType } from "@/types/annotations";
@@ -19,6 +19,7 @@ const tools: Array<{ type: ToolType; icon: React.ReactNode; label: string }> = [
   { type: "arrow", icon: <ArrowUpRight className="size-4" />, label: "Arrow" },
   { type: "number", icon: <Hash className="size-4" />, label: "Number" },
   { type: "text", icon: <Type className="size-4" />, label: "Text" },
+  { type: "blur", icon: <Scan className="size-4" />, label: "Blur an area" },
 ];
 
 export const AnnotationToolbar = memo(function AnnotationToolbar({ selectedTool, onToolSelect, onDelete }: AnnotationToolbarProps) {

--- a/src/components/editor/PropertiesPanel.tsx
+++ b/src/components/editor/PropertiesPanel.tsx
@@ -26,6 +26,12 @@ export const PropertiesPanel = memo(function PropertiesPanel({ annotation, onUpd
     if (annotation.type === "number") {
       newExpanded.add("number");
     }
+    if (annotation.type === "blur") {
+      newExpanded.add("blur");
+      // Don't show fill/border for blur
+      newExpanded.delete("fill");
+      newExpanded.delete("border");
+    }
     
     setExpandedSections(newExpanded);
   }, [annotation?.type, annotation?.id]);
@@ -70,6 +76,45 @@ export const PropertiesPanel = memo(function PropertiesPanel({ annotation, onUpd
 
   return (
     <div className="px-4 py-3 space-y-2">
+      {/* Blur Section - Only for blur annotations */}
+      {annotation.type === "blur" && (
+        <div className="space-y-1.5">
+          <button
+            onClick={() => toggleSection("blur")}
+            className="w-full flex items-center justify-between text-xs font-medium text-zinc-300 hover:text-zinc-50"
+          >
+            <span>Blur</span>
+            {expandedSections.has("blur") ? (
+              <ChevronUp className="size-3" />
+            ) : (
+              <ChevronDown className="size-3" />
+            )}
+          </button>
+          {expandedSections.has("blur") && (
+            <div className="space-y-2 pl-2">
+              <div>
+                <div className="text-xs text-zinc-500 mb-1.5">Intensity</div>
+                <div className="flex items-center gap-2">
+                  <Slider
+                    value={[annotation.blurAmount]}
+                    onValueChange={([value]) => updateAnnotation({ blurAmount: value })}
+                    min={1}
+                    max={50}
+                    step={1}
+                  />
+                  <input
+                    type="text"
+                    value={annotation.blurAmount}
+                    onChange={(e) => updateAnnotation({ blurAmount: Number(e.target.value) || 20 })}
+                    className="w-14 px-1.5 py-1 bg-zinc-800 border border-zinc-700 rounded text-xs text-zinc-100"
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Text Section - Only for text annotations */}
       {annotation.type === "text" && (
         <div className="space-y-1.5">
@@ -216,19 +261,20 @@ export const PropertiesPanel = memo(function PropertiesPanel({ annotation, onUpd
         </div>
       )}
 
-      {/* Fill Section */}
-      <div className="space-y-1.5">
-        <button
-          onClick={() => toggleSection("fill")}
-          className="w-full flex items-center justify-between text-xs font-medium text-zinc-300 hover:text-zinc-50"
-        >
-          <span>Fill</span>
-          {expandedSections.has("fill") ? (
-            <ChevronUp className="size-3" />
-          ) : (
-            <ChevronDown className="size-3" />
-          )}
-        </button>
+      {/* Fill Section - Hide for blur */}
+      {annotation.type !== "blur" && (
+        <div className="space-y-1.5">
+          <button
+            onClick={() => toggleSection("fill")}
+            className="w-full flex items-center justify-between text-xs font-medium text-zinc-300 hover:text-zinc-50"
+          >
+            <span>Fill</span>
+            {expandedSections.has("fill") ? (
+              <ChevronUp className="size-3" />
+            ) : (
+              <ChevronDown className="size-3" />
+            )}
+          </button>
         {expandedSections.has("fill") && (
           <div className="space-y-2 pl-2">
             <div>
@@ -265,21 +311,23 @@ export const PropertiesPanel = memo(function PropertiesPanel({ annotation, onUpd
             </div>
           </div>
         )}
-      </div>
+        </div>
+      )}
 
-      {/* Border Section */}
-      <div className="space-y-1.5">
-        <button
-          onClick={() => toggleSection("border")}
-          className="w-full flex items-center justify-between text-xs font-medium text-zinc-300 hover:text-zinc-50"
-        >
-          <span>Border</span>
-          {expandedSections.has("border") ? (
-            <ChevronUp className="size-3" />
-          ) : (
-            <ChevronDown className="size-3" />
-          )}
-        </button>
+      {/* Border Section - Hide for blur */}
+      {annotation.type !== "blur" && (
+        <div className="space-y-1.5">
+          <button
+            onClick={() => toggleSection("border")}
+            className="w-full flex items-center justify-between text-xs font-medium text-zinc-300 hover:text-zinc-50"
+          >
+            <span>Border</span>
+            {expandedSections.has("border") ? (
+              <ChevronUp className="size-3" />
+            ) : (
+              <ChevronDown className="size-3" />
+            )}
+          </button>
         {expandedSections.has("border") && (
           <div className="space-y-2 pl-2">
             <div>
@@ -336,7 +384,8 @@ export const PropertiesPanel = memo(function PropertiesPanel({ annotation, onUpd
             </div>
           </div>
         )}
-      </div>
+        </div>
+      )}
     </div>
   );
 });

--- a/src/types/annotations.ts
+++ b/src/types/annotations.ts
@@ -1,4 +1,4 @@
-export type ToolType = "circle" | "rectangle" | "line" | "arrow" | "text" | "number" | "select" | null;
+export type ToolType = "circle" | "rectangle" | "line" | "arrow" | "text" | "number" | "blur" | "select" | null;
 
 export type LineType = "straight" | "curved";
 
@@ -76,10 +76,18 @@ export interface NumberAnnotation extends BaseAnnotation {
   radius: number;
 }
 
+export interface BlurAnnotation extends BaseAnnotation {
+  type: "blur";
+  width: number;
+  height: number;
+  blurAmount: number;
+}
+
 export type Annotation =
   | CircleAnnotation
   | RectangleAnnotation
   | LineAnnotation
   | ArrowAnnotation
   | TextAnnotation
-  | NumberAnnotation;
+  | NumberAnnotation
+  | BlurAnnotation;


### PR DESCRIPTION
- Add new 'Blur an area' tool to annotation toolbar with Scan icon
- Implement BlurAnnotation type with width, height, and blurAmount properties
- Add performant two-pass box blur algorithm for image processing
- Integrate blur tool with properties panel (intensity slider 1-50)
- Add hit detection and selection highlighting for blur regions
- Hide Fill/Border properties for blur annotations (not applicable)
- Support full undo/redo functionality
- Add visual indicator (dashed border) for blur regions