### PR TITLE
Persist Editor Effect Settings

### DIFF
--- a/src/components/ImageEditor.tsx
+++ b/src/components/ImageEditor.tsx
@@ -458,6 +458,7 @@ export function ImageEditor({ imagePath, onSave, onCancel }: ImageEditorProps) {
                 onShadowOffsetXChange={actions.setShadowOffsetX}
                 onShadowOffsetYChange={actions.setShadowOffsetY}
                 onShadowOpacityChange={actions.setShadowOpacity}
+                onSaveAsDefaults={actions.saveEffectSettingsAsDefaults}
               />
 
               <ImageRoundnessControl


### PR DESCRIPTION
## Summary
Implemented persistence of editor effect settings across sessions, including:
- Added `saveEffectSettingsAsDefaults` method to `editorStore`
- Created "Set as Default" button in `EffectsPanel`
- Loaded default effect settings during store initialization
- Persists blur, noise, border radius, padding, and shadow settings

Key changes:
- Updated `editorStore.ts` to save and load effect settings
- Added save defaults button with toast notifications
- Implemented loading of persisted settings on app startup 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=6)](https://app.tembo.io/tasks/998b437c-d3fa-4ecd-bdb6-b33685aba917)  [![app.tembo.io](https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?v=1)](https://app.tembo.io/settings/agents)