### PR TITLE
Add Individual Padding Options

### DIFF
--- a/src-tauri/src/image.rs
+++ b/src-tauri/src/image.rs
@@ -136,7 +136,10 @@ pub struct RenderSettings {
     pub blur_amount: f32,
     pub noise_amount: f32,
     pub border_radius: f32,
-    pub padding: u32,
+    pub padding_top: u32,
+    pub padding_right: u32,
+    pub padding_bottom: u32,
+    pub padding_left: u32,
     pub shadow_blur: f32,
     pub shadow_offset_x: f32,
     pub shadow_offset_y: f32,
@@ -228,11 +231,13 @@ pub fn render_image_with_effects(
 ) -> AppResult<String> {
     let img = image::open(image_path)
         .map_err(|e| format!("Failed to open image: {}", e))?;
-    
+
     let img_width = img.width();
     let img_height = img.height();
-    let bg_width = img_width + settings.padding * 2;
-    let bg_height = img_height + settings.padding * 2;
+    let horizontal_padding = settings.padding_left + settings.padding_right;
+    let vertical_padding = settings.padding_top + settings.padding_bottom;
+    let bg_width = img_width + horizontal_padding;
+    let bg_height = img_height + vertical_padding;
     
     let mut background = create_background(
         bg_width,
@@ -254,13 +259,13 @@ pub fn render_image_with_effects(
     
     for y in 0..bg_height {
         for x in 0..bg_width {
-            if x >= settings.padding
-                && x < settings.padding + img_width
-                && y >= settings.padding
-                && y < settings.padding + img_height
+            if x >= settings.padding_left
+                && x < settings.padding_left + img_width
+                && y >= settings.padding_top
+                && y < settings.padding_top + img_height
             {
-                let img_x = x - settings.padding;
-                let img_y = y - settings.padding;
+                let img_x = x - settings.padding_left;
+                let img_y = y - settings.padding_top;
                 
                 let corner_x = if img_x < settings.border_radius as u32 {
                     img_x

--- a/src/components/ImageEditor.tsx
+++ b/src/components/ImageEditor.tsx
@@ -60,7 +60,12 @@ export function ImageEditor({ imagePath, onSave, onCancel }: ImageEditorProps) {
     screenshotImage,
     settings,
     canvasRef,
-    padding: settings.padding,
+    padding: {
+      top: settings.padding.top,
+      right: settings.padding.right,
+      bottom: settings.padding.bottom,
+      left: settings.padding.left,
+    },
     imagePath,
   });
 
@@ -119,7 +124,7 @@ export function ImageEditor({ imagePath, onSave, onCancel }: ImageEditorProps) {
       // Calculate smart default padding: 10% of average dimension, capped at 400px
       const avgDimension = (img.width + img.height) / 2;
       const defaultPadding = Math.min(Math.round(avgDimension * 0.1), 400);
-      actions.setPaddingTransient(defaultPadding);
+      actions.setPaddingUniformTransient(defaultPadding);
     };
     img.onerror = () => {
       setLoadError(`Failed to load image from: ${imagePath}`);
@@ -446,14 +451,24 @@ export function ImageEditor({ imagePath, onSave, onCancel }: ImageEditorProps) {
                 shadow={settings.shadow}
                 onBlurAmountChangeTransient={actions.setBlurAmountTransient}
                 onNoiseChangeTransient={actions.setNoiseAmountTransient}
-                onPaddingChangeTransient={actions.setPaddingTransient}
+                onPaddingUniformChangeTransient={actions.setPaddingUniformTransient}
+                onPaddingTopChangeTransient={actions.setPaddingTopTransient}
+                onPaddingRightChangeTransient={actions.setPaddingRightTransient}
+                onPaddingBottomChangeTransient={actions.setPaddingBottomTransient}
+                onPaddingLeftChangeTransient={actions.setPaddingLeftTransient}
+                onPaddingModeChangeTransient={actions.setPaddingModeTransient}
                 onShadowBlurChangeTransient={actions.setShadowBlurTransient}
                 onShadowOffsetXChangeTransient={actions.setShadowOffsetXTransient}
                 onShadowOffsetYChangeTransient={actions.setShadowOffsetYTransient}
                 onShadowOpacityChangeTransient={actions.setShadowOpacityTransient}
                 onBlurAmountChange={actions.setBlurAmount}
                 onNoiseChange={actions.setNoiseAmount}
-                onPaddingChange={actions.setPadding}
+                onPaddingUniformChange={actions.setPaddingUniform}
+                onPaddingTopChange={actions.setPaddingTop}
+                onPaddingRightChange={actions.setPaddingRight}
+                onPaddingBottomChange={actions.setPaddingBottom}
+                onPaddingLeftChange={actions.setPaddingLeft}
+                onPaddingModeChange={actions.setPaddingMode}
                 onShadowBlurChange={actions.setShadowBlur}
                 onShadowOffsetXChange={actions.setShadowOffsetX}
                 onShadowOffsetYChange={actions.setShadowOffsetY}

--- a/src/components/editor/EffectsPanel.tsx
+++ b/src/components/editor/EffectsPanel.tsx
@@ -1,20 +1,25 @@
 import { memo, useState } from "react";
 import { toast } from "sonner";
-import { Check, Bookmark } from "lucide-react";
+import { Check, Bookmark, Link2, Link2Off } from "lucide-react";
 import { Slider } from "@/components/ui/slider";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import type { ShadowSettings } from "@/stores/editorStore";
+import type { ShadowSettings, PaddingSettings, PaddingMode } from "@/stores/editorStore";
 
 interface EffectsPanelProps {
   blurAmount: number;
   noiseAmount: number;
-  padding: number;
+  padding: PaddingSettings;
   shadow: ShadowSettings;
   // Transient handlers (during drag) - for visual feedback
   onBlurAmountChangeTransient?: (value: number) => void;
   onNoiseChangeTransient?: (value: number) => void;
-  onPaddingChangeTransient?: (value: number) => void;
+  onPaddingUniformChangeTransient?: (value: number) => void;
+  onPaddingTopChangeTransient?: (value: number) => void;
+  onPaddingRightChangeTransient?: (value: number) => void;
+  onPaddingBottomChangeTransient?: (value: number) => void;
+  onPaddingLeftChangeTransient?: (value: number) => void;
+  onPaddingModeChangeTransient?: (mode: PaddingMode) => void;
   onShadowBlurChangeTransient?: (value: number) => void;
   onShadowOffsetXChangeTransient?: (value: number) => void;
   onShadowOffsetYChangeTransient?: (value: number) => void;
@@ -22,7 +27,12 @@ interface EffectsPanelProps {
   // Commit handlers (on release) - for state/history
   onBlurAmountChange: (value: number) => void;
   onNoiseChange: (value: number) => void;
-  onPaddingChange: (value: number) => void;
+  onPaddingUniformChange: (value: number) => void;
+  onPaddingTopChange: (value: number) => void;
+  onPaddingRightChange: (value: number) => void;
+  onPaddingBottomChange: (value: number) => void;
+  onPaddingLeftChange: (value: number) => void;
+  onPaddingModeChange: (mode: PaddingMode) => void;
   onShadowBlurChange: (value: number) => void;
   onShadowOffsetXChange: (value: number) => void;
   onShadowOffsetYChange: (value: number) => void;
@@ -38,14 +48,24 @@ export const EffectsPanel = memo(function EffectsPanel({
   shadow,
   onBlurAmountChangeTransient,
   onNoiseChangeTransient,
-  onPaddingChangeTransient,
+  onPaddingUniformChangeTransient,
+  onPaddingTopChangeTransient,
+  onPaddingRightChangeTransient,
+  onPaddingBottomChangeTransient,
+  onPaddingLeftChangeTransient,
+  onPaddingModeChangeTransient,
   onShadowBlurChangeTransient,
   onShadowOffsetXChangeTransient,
   onShadowOffsetYChangeTransient,
   onShadowOpacityChangeTransient,
   onBlurAmountChange,
   onNoiseChange,
-  onPaddingChange,
+  onPaddingUniformChange,
+  onPaddingTopChange,
+  onPaddingRightChange,
+  onPaddingBottomChange,
+  onPaddingLeftChange,
+  onPaddingModeChange,
   onShadowBlurChange,
   onShadowOffsetXChange,
   onShadowOffsetYChange,
@@ -133,17 +153,113 @@ export const EffectsPanel = memo(function EffectsPanel({
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
-              <span className="text-xs text-muted-foreground font-mono tabular-nums">{padding}px</span>
+              <div className="flex items-center gap-2">
+                {padding.mode === "uniform" && (
+                  <span className="text-xs text-muted-foreground font-mono tabular-nums">{padding.uniform}px</span>
+                )}
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-6"
+                        onClick={() => {
+                          const newMode = padding.mode === "uniform" ? "individual" : "uniform";
+                          onPaddingModeChangeTransient?.(newMode);
+                          onPaddingModeChange(newMode);
+                        }}
+                        aria-label={padding.mode === "uniform" ? "Switch to individual padding" : "Switch to uniform padding"}
+                      >
+                        {padding.mode === "uniform" ? (
+                          <Link2 className="size-3.5" aria-hidden="true" />
+                        ) : (
+                          <Link2Off className="size-3.5" aria-hidden="true" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="left">
+                      <p className="text-xs">{padding.mode === "uniform" ? "Individual padding" : "Uniform padding"}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
             </div>
-            <Slider
-              value={[padding]}
-              onValueChange={(value) => onPaddingChangeTransient?.(value[0])}
-              onValueCommit={(value) => onPaddingChange(value[0])}
-              min={0}
-              max={maxPadding}
-              step={1}
-              className="w-full"
-            />
+
+            {padding.mode === "uniform" ? (
+              <Slider
+                value={[padding.uniform]}
+                onValueChange={(value) => onPaddingUniformChangeTransient?.(value[0])}
+                onValueCommit={(value) => onPaddingUniformChange(value[0])}
+                min={0}
+                max={maxPadding}
+                step={1}
+                className="w-full"
+              />
+            ) : (
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <label className="text-xs text-muted-foreground">Top</label>
+                    <span className="text-xs text-muted-foreground font-mono tabular-nums">{padding.top}px</span>
+                  </div>
+                  <Slider
+                    value={[padding.top]}
+                    onValueChange={(value) => onPaddingTopChangeTransient?.(value[0])}
+                    onValueCommit={(value) => onPaddingTopChange(value[0])}
+                    min={0}
+                    max={maxPadding}
+                    step={1}
+                    className="w-full"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <label className="text-xs text-muted-foreground">Right</label>
+                    <span className="text-xs text-muted-foreground font-mono tabular-nums">{padding.right}px</span>
+                  </div>
+                  <Slider
+                    value={[padding.right]}
+                    onValueChange={(value) => onPaddingRightChangeTransient?.(value[0])}
+                    onValueCommit={(value) => onPaddingRightChange(value[0])}
+                    min={0}
+                    max={maxPadding}
+                    step={1}
+                    className="w-full"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <label className="text-xs text-muted-foreground">Bottom</label>
+                    <span className="text-xs text-muted-foreground font-mono tabular-nums">{padding.bottom}px</span>
+                  </div>
+                  <Slider
+                    value={[padding.bottom]}
+                    onValueChange={(value) => onPaddingBottomChangeTransient?.(value[0])}
+                    onValueCommit={(value) => onPaddingBottomChange(value[0])}
+                    min={0}
+                    max={maxPadding}
+                    step={1}
+                    className="w-full"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <label className="text-xs text-muted-foreground">Left</label>
+                    <span className="text-xs text-muted-foreground font-mono tabular-nums">{padding.left}px</span>
+                  </div>
+                  <Slider
+                    value={[padding.left]}
+                    onValueChange={(value) => onPaddingLeftChangeTransient?.(value[0])}
+                    onValueCommit={(value) => onPaddingLeftChange(value[0])}
+                    min={0}
+                    max={maxPadding}
+                    step={1}
+                    className="w-full"
+                  />
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/lib/auto-process.ts
+++ b/src/lib/auto-process.ts
@@ -57,7 +57,12 @@ export async function processScreenshotWithDefaultBackground(
                 blurAmount: 0,
                 noiseAmount: 20,
                 borderRadius: 18,
-                padding,
+                padding: {
+                  top: padding,
+                  right: padding,
+                  bottom: padding,
+                  left: padding,
+                },
                 gradientImage: isGradient ? bgImage : null,
                 shadow: {
                   blur: 33,
@@ -111,7 +116,12 @@ export async function processScreenshotWithDefaultBackground(
               blurAmount,
               noiseAmount: 20,
               borderRadius: 18,
-              padding: finalPadding,
+              padding: {
+                top: finalPadding,
+                right: finalPadding,
+                bottom: finalPadding,
+                left: finalPadding,
+              },
               shadow: isTransparent ? {
                 blur: 0,
                 offsetX: 0,

--- a/src/lib/canvas-utils.ts
+++ b/src/lib/canvas-utils.ts
@@ -1,5 +1,12 @@
 import type { ShadowSettings } from "@/hooks/useEditorSettings";
 
+export interface PaddingValues {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
 export interface RenderOptions {
   image: HTMLImageElement;
   backgroundType: "transparent" | "white" | "black" | "gray" | "gradient" | "custom" | "image";
@@ -9,7 +16,7 @@ export interface RenderOptions {
   blurAmount: number;
   noiseAmount: number;
   borderRadius: number;
-  padding: number;
+  padding: PaddingValues;
   scale?: number;
   gradientImage?: HTMLImageElement | null;
   shadow?: ShadowSettings;
@@ -32,8 +39,12 @@ export function createHighQualityCanvas(options: RenderOptions): HTMLCanvasEleme
     shadow = { blur: 33, offsetX: 18, offsetY: 23, opacity: 39 },
   } = options;
 
-  const bgWidth = image.width + padding * 2;
-  const bgHeight = image.height + padding * 2;
+  const { top: paddingTop, right: paddingRight, bottom: paddingBottom, left: paddingLeft } = padding;
+  const totalHorizontalPadding = paddingLeft + paddingRight;
+  const totalVerticalPadding = paddingTop + paddingBottom;
+
+  const bgWidth = image.width + totalHorizontalPadding;
+  const bgHeight = image.height + totalVerticalPadding;
 
   const canvas = document.createElement("canvas");
   canvas.width = bgWidth * scale;
@@ -48,8 +59,9 @@ export function createHighQualityCanvas(options: RenderOptions): HTMLCanvasEleme
   ctx.imageSmoothingEnabled = true;
   ctx.imageSmoothingQuality = "high";
 
-  // When padding is 0, skip background and shadow - just draw the image directly
-  if (padding === 0) {
+  // When all padding values are 0, skip background and shadow - just draw the image directly
+  const hasNoPadding = totalHorizontalPadding === 0 && totalVerticalPadding === 0;
+  if (hasNoPadding) {
     ctx.beginPath();
     ctx.roundRect(0, 0, image.width, image.height, borderRadius);
     ctx.closePath();
@@ -96,7 +108,7 @@ export function createHighQualityCanvas(options: RenderOptions): HTMLCanvasEleme
     ctx.shadowOffsetX = shadow.offsetX;
     ctx.shadowOffsetY = shadow.offsetY;
 
-    ctx.drawImage(imageCanvas, padding, padding);
+    ctx.drawImage(imageCanvas, paddingLeft, paddingTop);
 
     ctx.shadowColor = "transparent";
     ctx.shadowBlur = 0;


### PR DESCRIPTION
## Summary
Implement individual padding controls for image export with support for uniform and individual padding modes

### Changes
- Extended padding from single value to support individual top, right, bottom, and left padding
- Added a toggle to switch between uniform and individual padding modes
- Updated Rust backend (`src-tauri/src/image.rs`) to support individual padding
- Modified preview generation and canvas rendering to use individual padding values
- Updated tests and store logic to handle new padding structure

### Implementation Details
- Added `PaddingMode` type with `uniform` and `individual` options
- Created `PaddingSettings` interface with mode and individual padding values
- Updated UI in `EffectsPanel` to support individual sliders
- Maintained existing code patterns and test coverage

### Breaking Changes
- Padding is now an object instead of a single number
- Existing code that directly accesses `settings.padding` will need to be updated

### Testing
- Comprehensive test suite updated to cover new padding functionality
- Verified rendering with both uniform and individual padding modes 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=6)](https://app.tembo.io/tasks/1beadea2-f0cf-4544-bb2c-25b83ac8fa7f)  [![app.tembo.io](https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?v=1)](https://app.tembo.io/settings/agents)