### PR TITLE
feat: SCP upload, auto-clipboard, arrow default, stable signing

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -50,6 +50,11 @@ pub async fn copy_image_file_to_clipboard(path: String) -> Result<(), String> {
     copy_image_to_clipboard(&path).map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+pub async fn copy_text_to_clipboard_cmd(text: String) -> Result<(), String> {
+    copy_text_to_clipboard(&text).map_err(|e| e.to_string())
+}
+
 /// Quick capture of primary monitor
 #[tauri::command]
 pub async fn capture_once(

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -127,6 +127,59 @@ pub async fn save_edited_image(
     Ok(saved_path)
 }
 
+/// Upload a file to a remote server via SCP
+/// Skips upload if the local hostname matches the remote host (already on the target machine)
+#[tauri::command]
+pub async fn scp_upload(
+    local_path: String,
+    remote_user: String,
+    remote_host: String,
+    remote_dir: String,
+) -> Result<String, String> {
+    // Skip if we're already on the remote host
+    let local_hostname = Command::new("hostname")
+        .output()
+        .ok()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    if local_hostname == remote_host || remote_host.starts_with(&format!("{}.", local_hostname)) {
+        // Already on the target machine, just copy locally
+        let path = std::path::Path::new(&local_path);
+        let filename = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| "Invalid file path".to_string())?;
+        let dest = format!("{}/{}", remote_dir, filename);
+        std::fs::copy(&local_path, &dest)
+            .map_err(|e| format!("Local copy failed: {}", e))?;
+        return Ok(dest);
+    }
+
+    let path = std::path::Path::new(&local_path);
+    let filename = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "Invalid file path".to_string())?;
+
+    let remote_dest = format!("{}@{}:{}/{}", remote_user, remote_host, remote_dir, filename);
+
+    let output = Command::new("scp")
+        .arg("-o").arg("StrictHostKeyChecking=accept-new")
+        .arg("-o").arg("ConnectTimeout=10")
+        .arg(&local_path)
+        .arg(&remote_dest)
+        .output()
+        .map_err(|e| format!("Failed to execute scp: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("SCP failed: {}", stderr));
+    }
+
+    let remote_path = format!("{}/{}", remote_dir, filename);
+    Ok(remote_path)
+}
+
 /// Get the user's Desktop directory path (cross-platform)
 #[tauri::command]
 pub async fn get_desktop_directory() -> Result<String, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,7 +16,7 @@ use commands::{
     copy_text_to_clipboard_cmd, get_desktop_directory, get_mouse_position, get_temp_directory,
     move_window_to_active_space, native_capture_fullscreen, native_capture_interactive,
     native_capture_window, native_capture_ocr_region, play_screenshot_sound,
-    render_image_with_effects_rust, save_edited_image,
+    render_image_with_effects_rust, save_edited_image, scp_upload,
 };
 
 use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
@@ -258,7 +258,8 @@ pub fn run() {
             get_mouse_position,
             move_window_to_active_space,
             copy_image_file_to_clipboard,
-            copy_text_to_clipboard_cmd
+            copy_text_to_clipboard_cmd,
+            scp_upload
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,9 +13,10 @@ mod utils;
 
 use commands::{
     capture_all_monitors, capture_once, capture_region, copy_image_file_to_clipboard,
-    get_desktop_directory, get_mouse_position, get_temp_directory, move_window_to_active_space,
-    native_capture_fullscreen, native_capture_interactive, native_capture_window,
-    native_capture_ocr_region, play_screenshot_sound, render_image_with_effects_rust, save_edited_image,
+    copy_text_to_clipboard_cmd, get_desktop_directory, get_mouse_position, get_temp_directory,
+    move_window_to_active_space, native_capture_fullscreen, native_capture_interactive,
+    native_capture_window, native_capture_ocr_region, play_screenshot_sound,
+    render_image_with_effects_rust, save_edited_image,
 };
 
 use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
@@ -256,7 +257,8 @@ pub fn run() {
             play_screenshot_sound,
             get_mouse_position,
             move_window_to_active_space,
-            copy_image_file_to_clipboard
+            copy_image_file_to_clipboard,
+            copy_text_to_clipboard_cmd
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,7 @@
       "icons/icon.ico"
     ],
     "macOS": {
-      "signingIdentity": "-"
+      "signingIdentity": "Apple Development: Yizhou He (U4HVU5232W)"
     }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -214,6 +214,7 @@ function App() {
   const [mode, setMode] = useState<AppMode>("main");
   const [saveDir, setSaveDir] = useState<string>("");
   const [copyToClipboard, setCopyToClipboard] = useState(true);
+  const [copyFilepathToClipboard, setCopyFilepathToClipboard] = useState(false);
   const [autoApplyBackground, setAutoApplyBackground] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isCapturing, setIsCapturing] = useState(false);
@@ -224,14 +225,14 @@ function App() {
   const [tempDir, setTempDir] = useState<string>("/tmp");
 
   // Refs to hold current values for use in callbacks that may have stale closures
-  const settingsRef = useRef({ autoApplyBackground, saveDir, copyToClipboard, tempDir });
+  const settingsRef = useRef({ autoApplyBackground, saveDir, copyToClipboard, copyFilepathToClipboard, tempDir });
   const registeredShortcutsRef = useRef<Set<string>>(new Set());
   const lastCaptureTimeRef = useRef(0);
-  
+
   // Keep ref in sync with state
   useEffect(() => {
-    settingsRef.current = { autoApplyBackground, saveDir, copyToClipboard, tempDir };
-  }, [autoApplyBackground, saveDir, copyToClipboard, tempDir]);
+    settingsRef.current = { autoApplyBackground, saveDir, copyToClipboard, copyFilepathToClipboard, tempDir };
+  }, [autoApplyBackground, saveDir, copyToClipboard, copyFilepathToClipboard, tempDir]);
 
   // Load settings function
   const loadSettings = useCallback(async () => {
@@ -247,6 +248,11 @@ function App() {
       const savedCopyToClip = await store.get<boolean>("copyToClipboard");
       if (savedCopyToClip !== null && savedCopyToClip !== undefined) {
         setCopyToClipboard(savedCopyToClip);
+      }
+
+      const savedCopyFilepath = await store.get<boolean>("copyFilepathToClipboard");
+      if (savedCopyFilepath !== null && savedCopyFilepath !== undefined) {
+        setCopyFilepathToClipboard(savedCopyFilepath);
       }
 
       const savedAutoApply = await store.get<boolean>("autoApplyBackground");
@@ -309,6 +315,11 @@ function App() {
         const savedCopyToClip = await store.get<boolean>("copyToClipboard");
         if (savedCopyToClip !== null && savedCopyToClip !== undefined) {
           setCopyToClipboard(savedCopyToClip);
+        }
+
+        const savedCopyFilepath = await store.get<boolean>("copyFilepathToClipboard");
+        if (savedCopyFilepath !== null && savedCopyFilepath !== undefined) {
+          setCopyFilepathToClipboard(savedCopyFilepath);
         }
 
         const savedAutoApply = await store.get<boolean>("autoApplyBackground");
@@ -382,7 +393,7 @@ function App() {
     const appWindow = getCurrentWindow();
     
     // Read current settings from ref to avoid stale closure issues
-    const { autoApplyBackground: shouldAutoApply, saveDir: currentSaveDir, copyToClipboard: shouldCopyToClipboard, tempDir: currentTempDir } = settingsRef.current;
+    const { autoApplyBackground: shouldAutoApply, saveDir: currentSaveDir, copyToClipboard: shouldCopyToClipboard, copyFilepathToClipboard: shouldCopyFilepath, tempDir: currentTempDir } = settingsRef.current;
 
     try {
       await appWindow.hide();
@@ -462,8 +473,12 @@ function App() {
           const savedPath = await invoke<string>("save_edited_image", {
             imageData: processedImageData,
             saveDir: currentSaveDir,
-            copyToClip: shouldCopyToClipboard,
+            copyToClip: shouldCopyToClipboard && !shouldCopyFilepath,
           });
+
+          if (shouldCopyFilepath) {
+            await invoke("copy_text_to_clipboard_cmd", { text: savedPath });
+          }
 
           await appWindow.hide();
           await showQuickOverlay(savedPath, mouseX, mouseY);
@@ -678,8 +693,12 @@ function App() {
       const savedPath = await invoke<string>("save_edited_image", {
         imageData: editedImageData,
         saveDir,
-        copyToClip: copyToClipboard,
+        copyToClip: copyToClipboard && !copyFilepathToClipboard,
       });
+
+      if (copyFilepathToClipboard) {
+        await invoke("copy_text_to_clipboard_cmd", { text: savedPath });
+      }
 
       toast.success("Image saved", {
         description: savedPath,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -223,16 +223,20 @@ function App() {
   const [shortcuts, setShortcuts] = useState<KeyboardShortcut[]>(DEFAULT_SHORTCUTS);
   const [settingsVersion, setSettingsVersion] = useState(0);
   const [tempDir, setTempDir] = useState<string>("/tmp");
+  const [scpEnabled, setScpEnabled] = useState(false);
+  const [scpUser, setScpUser] = useState("");
+  const [scpHost, setScpHost] = useState("");
+  const [scpRemoteDir, setScpRemoteDir] = useState("");
 
   // Refs to hold current values for use in callbacks that may have stale closures
-  const settingsRef = useRef({ autoApplyBackground, saveDir, copyToClipboard, copyFilepathToClipboard, tempDir });
+  const settingsRef = useRef({ autoApplyBackground, saveDir, copyToClipboard, copyFilepathToClipboard, tempDir, scpEnabled, scpUser, scpHost, scpRemoteDir });
   const registeredShortcutsRef = useRef<Set<string>>(new Set());
   const lastCaptureTimeRef = useRef(0);
 
   // Keep ref in sync with state
   useEffect(() => {
-    settingsRef.current = { autoApplyBackground, saveDir, copyToClipboard, copyFilepathToClipboard, tempDir };
-  }, [autoApplyBackground, saveDir, copyToClipboard, copyFilepathToClipboard, tempDir]);
+    settingsRef.current = { autoApplyBackground, saveDir, copyToClipboard, copyFilepathToClipboard, tempDir, scpEnabled, scpUser, scpHost, scpRemoteDir };
+  }, [autoApplyBackground, saveDir, copyToClipboard, copyFilepathToClipboard, tempDir, scpEnabled, scpUser, scpHost, scpRemoteDir]);
 
   // Load settings function
   const loadSettings = useCallback(async () => {
@@ -264,6 +268,15 @@ function App() {
       if (savedSaveDir) {
         setSaveDir(savedSaveDir);
       }
+
+      const savedScpEnabled = await store.get<boolean>("scpEnabled");
+      if (savedScpEnabled !== null && savedScpEnabled !== undefined) setScpEnabled(savedScpEnabled);
+      const savedScpUser = await store.get<string>("scpUser");
+      if (savedScpUser) setScpUser(savedScpUser);
+      const savedScpHost = await store.get<string>("scpHost");
+      if (savedScpHost) setScpHost(savedScpHost);
+      const savedScpRemoteDir = await store.get<string>("scpRemoteDir");
+      if (savedScpRemoteDir) setScpRemoteDir(savedScpRemoteDir);
 
       const savedShortcuts = await store.get<KeyboardShortcut[]>("keyboardShortcuts");
       if (savedShortcuts && savedShortcuts.length > 0) {
@@ -340,6 +353,15 @@ function App() {
           }
         }
 
+        const savedScpEnabled2 = await store.get<boolean>("scpEnabled");
+        if (savedScpEnabled2 !== null && savedScpEnabled2 !== undefined) setScpEnabled(savedScpEnabled2);
+        const savedScpUser2 = await store.get<string>("scpUser");
+        if (savedScpUser2) setScpUser(savedScpUser2);
+        const savedScpHost2 = await store.get<string>("scpHost");
+        if (savedScpHost2) setScpHost(savedScpHost2);
+        const savedScpRemoteDir2 = await store.get<string>("scpRemoteDir");
+        if (savedScpRemoteDir2) setScpRemoteDir(savedScpRemoteDir2);
+
         const savedShortcuts = await store.get<KeyboardShortcut[]>("keyboardShortcuts");
         if (savedShortcuts && savedShortcuts.length > 0) {
           setShortcuts(savedShortcuts);
@@ -393,7 +415,7 @@ function App() {
     const appWindow = getCurrentWindow();
     
     // Read current settings from ref to avoid stale closure issues
-    const { autoApplyBackground: shouldAutoApply, saveDir: currentSaveDir, copyToClipboard: shouldCopyToClipboard, copyFilepathToClipboard: shouldCopyFilepath, tempDir: currentTempDir } = settingsRef.current;
+    const { autoApplyBackground: shouldAutoApply, saveDir: currentSaveDir, copyToClipboard: shouldCopyToClipboard, copyFilepathToClipboard: shouldCopyFilepath, tempDir: currentTempDir, scpEnabled: shouldScp, scpUser: currentScpUser, scpHost: currentScpHost, scpRemoteDir: currentScpRemoteDir } = settingsRef.current;
 
     try {
       await appWindow.hide();
@@ -478,6 +500,21 @@ function App() {
 
           if (shouldCopyFilepath) {
             await invoke("copy_text_to_clipboard_cmd", { text: savedPath });
+          }
+
+          // SCP upload if enabled
+          if (shouldScp && currentScpUser && currentScpHost && currentScpRemoteDir) {
+            invoke<string>("scp_upload", {
+              localPath: savedPath,
+              remoteUser: currentScpUser,
+              remoteHost: currentScpHost,
+              remoteDir: currentScpRemoteDir,
+            }).then((remotePath) => {
+              invoke("copy_text_to_clipboard_cmd", { text: `${currentScpHost}:${remotePath}` });
+              toast.success("Uploaded to remote", { description: remotePath, duration: 3000 });
+            }).catch((err) => {
+              toast.error("SCP upload failed", { description: String(err), duration: 5000 });
+            });
           }
 
           await appWindow.hide();
@@ -698,6 +735,21 @@ function App() {
 
       if (copyFilepathToClipboard) {
         await invoke("copy_text_to_clipboard_cmd", { text: savedPath });
+      }
+
+      // SCP upload if enabled
+      if (scpEnabled && scpUser && scpHost && scpRemoteDir) {
+        invoke<string>("scp_upload", {
+          localPath: savedPath,
+          remoteUser: scpUser,
+          remoteHost: scpHost,
+          remoteDir: scpRemoteDir,
+        }).then((remotePath) => {
+          invoke("copy_text_to_clipboard_cmd", { text: `${scpHost}:${remotePath}` });
+          toast.success("Uploaded to remote", { description: remotePath, duration: 3000 });
+        }).catch((err) => {
+          toast.error("SCP upload failed", { description: String(err), duration: 5000 });
+        });
       }
 
       toast.success("Image saved", {

--- a/src/components/ImageEditor.tsx
+++ b/src/components/ImageEditor.tsx
@@ -50,7 +50,7 @@ export function ImageEditor({ imagePath, onSave, onCancel }: ImageEditorProps) {
   const [tempDir, setTempDir] = useState<string>("/private/tmp");
 
    // Annotation UI state (not part of undo/redo)
-  const [selectedTool, setSelectedTool] = useState<ToolType>("select");
+  const [selectedTool, setSelectedTool] = useState<ToolType>("arrow");
   const [selectedAnnotation, setSelectedAnnotation] = useState<Annotation | null>(null);
   
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -216,14 +216,40 @@ export function ImageEditor({ imagePath, onSave, onCancel }: ImageEditorProps) {
     }
   }, [screenshotImage, annotations, renderHighQualityCanvas, isSaving, isCopying, tempDir, imagePath]);
 
+  // Silent copy to clipboard (no toast, no loading state)
+  const silentCopyToClipboard = useCallback(async (anns: Annotation[]) => {
+    if (!screenshotImage) return;
+    try {
+      const canvas = await renderHighQualityCanvas(anns, imagePath);
+      if (!canvas) return;
+      const dataUrl = canvas.toDataURL("image/png");
+      await invoke("save_edited_image", {
+        imageData: dataUrl,
+        saveDir: tempDir,
+        copyToClip: true,
+      });
+    } catch (e) {
+      console.error("Auto-copy failed:", e);
+    }
+  }, [screenshotImage, renderHighQualityCanvas, imagePath, tempDir]);
+
+  // Copy raw screenshot to clipboard when image first loads
+  useEffect(() => {
+    if (imageLoaded && imagePath) {
+      invoke("copy_image_file_to_clipboard", { path: imagePath }).catch(console.error);
+    }
+  }, [imageLoaded, imagePath]);
+
   // Annotation handlers
   const handleAnnotationAdd = useCallback((annotation: Annotation) => {
     actions.addAnnotation(annotation);
     setSelectedAnnotation(annotation);
-    if (annotation.type !== "number") {
+    if (annotation.type !== "number" && annotation.type !== "arrow") {
       setSelectedTool("select");
     }
-  }, [actions]);
+    // Auto-copy with the new annotation included
+    silentCopyToClipboard([...annotations, annotation]);
+  }, [actions, annotations, silentCopyToClipboard]);
 
   const handleAnnotationUpdateTransient = useCallback((annotation: Annotation) => {
     actions.updateAnnotationTransient(annotation);

--- a/src/components/preferences/PreferencesPage.tsx
+++ b/src/components/preferences/PreferencesPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { Store } from "@tauri-apps/plugin-store";
-import { ArrowLeft, Folder } from "lucide-react";
+import { ArrowLeft, Folder, Upload } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -18,6 +18,10 @@ interface GeneralSettings {
   saveDir: string;
   copyToClipboard: boolean;
   copyFilepathToClipboard: boolean;
+  scpEnabled: boolean;
+  scpUser: string;
+  scpHost: string;
+  scpRemoteDir: string;
 }
 
 export function PreferencesPage({ onBack, onSettingsChange }: PreferencesPageProps) {
@@ -25,6 +29,10 @@ export function PreferencesPage({ onBack, onSettingsChange }: PreferencesPagePro
     saveDir: "",
     copyToClipboard: true,
     copyFilepathToClipboard: false,
+    scpEnabled: true,
+    scpUser: "mikehe",
+    scpHost: "work16.local.org",
+    scpRemoteDir: "",
   });
   const [isLoading, setIsLoading] = useState(true);
 
@@ -33,15 +41,23 @@ export function PreferencesPage({ onBack, onSettingsChange }: PreferencesPagePro
     const loadSettings = async () => {
       try {
         const store = await Store.load("settings.json");
-        
+
         const copyToClip = await store.get<boolean>("copyToClipboard");
         const copyFilepath = await store.get<boolean>("copyFilepathToClipboard");
         const saveDir = await store.get<string>("saveDir");
+        const scpEnabled = await store.get<boolean>("scpEnabled");
+        const scpUser = await store.get<string>("scpUser");
+        const scpHost = await store.get<string>("scpHost");
+        const scpRemoteDir = await store.get<string>("scpRemoteDir");
 
         setSettings({
           saveDir: saveDir || "",
           copyToClipboard: copyToClip ?? true,
           copyFilepathToClipboard: copyFilepath ?? false,
+          scpEnabled: scpEnabled ?? true,
+          scpUser: scpUser || "mikehe",
+          scpHost: scpHost || "work16.local.org",
+          scpRemoteDir: scpRemoteDir || "",
         });
       } catch (err) {
         console.error("Failed to load settings:", err);
@@ -142,7 +158,7 @@ export function PreferencesPage({ onBack, onSettingsChange }: PreferencesPagePro
                 <label htmlFor="copy-clipboard" className="text-sm font-medium text-foreground cursor-pointer block">
                   Copy to clipboard
                 </label>
-                <p className="text-xs text-foreground0">Automatically copy screenshots to clipboard after saving</p>
+                <p className="text-xs text-foreground0">Automatically copy screenshots to clipboard when switching apps</p>
               </div>
               <Switch
                 id="copy-clipboard"
@@ -165,6 +181,69 @@ export function PreferencesPage({ onBack, onSettingsChange }: PreferencesPagePro
                 onCheckedChange={(checked) => updateSetting("copyFilepathToClipboard", checked)}
               />
             </div>
+          </CardContent>
+        </Card>
+
+        {/* Remote Upload (SCP) */}
+        <Card className="bg-card border-border">
+          <CardHeader className="pb-4">
+            <CardTitle className="text-lg font-semibold text-card-foreground flex items-center gap-2">
+              <Upload className="size-5" aria-hidden="true" />
+              Remote Upload (SCP)
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <div className="flex items-center justify-between py-2">
+              <div>
+                <label htmlFor="scp-enabled" className="text-sm font-medium text-foreground cursor-pointer block">
+                  Enable SCP upload
+                </label>
+                <p className="text-xs text-foreground0">Auto-upload screenshots to a remote server after saving</p>
+              </div>
+              <Switch
+                id="scp-enabled"
+                checked={settings.scpEnabled}
+                onCheckedChange={(checked) => updateSetting("scpEnabled", checked)}
+              />
+            </div>
+
+            {settings.scpEnabled && (
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <label htmlFor="scp-user" className="text-sm font-medium text-foreground">Username</label>
+                  <input
+                    id="scp-user"
+                    type="text"
+                    value={settings.scpUser}
+                    onChange={(e) => updateSetting("scpUser", e.target.value)}
+                    placeholder="e.g., mike"
+                    className="w-full px-3 py-2 bg-secondary border border-border rounded-lg text-card-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 transition-all font-mono text-sm"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label htmlFor="scp-host" className="text-sm font-medium text-foreground">Host</label>
+                  <input
+                    id="scp-host"
+                    type="text"
+                    value={settings.scpHost}
+                    onChange={(e) => updateSetting("scpHost", e.target.value)}
+                    placeholder="e.g., myserver.com"
+                    className="w-full px-3 py-2 bg-secondary border border-border rounded-lg text-card-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 transition-all font-mono text-sm"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label htmlFor="scp-remote-dir" className="text-sm font-medium text-foreground">Remote Directory</label>
+                  <input
+                    id="scp-remote-dir"
+                    type="text"
+                    value={settings.scpRemoteDir}
+                    onChange={(e) => updateSetting("scpRemoteDir", e.target.value)}
+                    placeholder="e.g., /home/mike/screenshots"
+                    className="w-full px-3 py-2 bg-secondary border border-border rounded-lg text-card-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 transition-all font-mono text-sm"
+                  />
+                </div>
+              </div>
+            )}
           </CardContent>
         </Card>
 

--- a/src/components/preferences/PreferencesPage.tsx
+++ b/src/components/preferences/PreferencesPage.tsx
@@ -17,12 +17,14 @@ interface PreferencesPageProps {
 interface GeneralSettings {
   saveDir: string;
   copyToClipboard: boolean;
+  copyFilepathToClipboard: boolean;
 }
 
 export function PreferencesPage({ onBack, onSettingsChange }: PreferencesPageProps) {
   const [settings, setSettings] = useState<GeneralSettings>({
     saveDir: "",
     copyToClipboard: true,
+    copyFilepathToClipboard: false,
   });
   const [isLoading, setIsLoading] = useState(true);
 
@@ -33,11 +35,13 @@ export function PreferencesPage({ onBack, onSettingsChange }: PreferencesPagePro
         const store = await Store.load("settings.json");
         
         const copyToClip = await store.get<boolean>("copyToClipboard");
+        const copyFilepath = await store.get<boolean>("copyFilepathToClipboard");
         const saveDir = await store.get<string>("saveDir");
-        
+
         setSettings({
           saveDir: saveDir || "",
           copyToClipboard: copyToClip ?? true,
+          copyFilepathToClipboard: copyFilepath ?? false,
         });
       } catch (err) {
         console.error("Failed to load settings:", err);
@@ -144,6 +148,21 @@ export function PreferencesPage({ onBack, onSettingsChange }: PreferencesPagePro
                 id="copy-clipboard"
                 checked={settings.copyToClipboard}
                 onCheckedChange={(checked) => updateSetting("copyToClipboard", checked)}
+              />
+            </div>
+
+            {/* Copy Filepath to Clipboard */}
+            <div className="flex items-center justify-between py-2">
+              <div>
+                <label htmlFor="copy-filepath" className="text-sm font-medium text-foreground cursor-pointer block">
+                  Copy filepath to clipboard
+                </label>
+                <p className="text-xs text-foreground0">Copy the saved file path to clipboard after saving</p>
+              </div>
+              <Switch
+                id="copy-filepath"
+                checked={settings.copyFilepathToClipboard}
+                onCheckedChange={(checked) => updateSetting("copyFilepathToClipboard", checked)}
               />
             </div>
           </CardContent>


### PR DESCRIPTION
## Summary
- **SCP upload**: Auto-upload screenshots to a remote server (via SCP) after saving, with configurable user/host/directory in Preferences. Intelligently skips SCP when running on the target host and does a local copy instead.
- **Auto-clipboard**: Copies raw screenshot to clipboard when editor opens, and re-copies (with annotations) after each annotation is added.
- **Arrow tool default**: Arrow annotation tool is pre-selected when the editor opens and stays active after drawing.
- **Stable code signing**: Uses Apple Development certificate instead of ad-hoc signing to preserve macOS Screen Recording permissions across rebuilds.

## Test plan
- [ ] Take a screenshot and verify it's copied to clipboard immediately
- [ ] Add an arrow annotation and paste — verify the annotated image is in clipboard
- [ ] Verify arrow tool stays selected after drawing an arrow
- [ ] Enable SCP in Preferences, configure remote host, save a screenshot — verify file appears on remote
- [ ] Run on the target host (e.g. work16) — verify local copy instead of SCP
- [ ] Rebuild and reinstall — verify Screen Recording permission is retained

Generated with Claude Code