### PR TITLE
feat: add app appearance setting

### DIFF
--- a/Sources/App/BetterShotDelegate.swift
+++ b/Sources/App/BetterShotDelegate.swift
@@ -5,7 +5,7 @@ final class BetterShotDelegate: NSObject, NSApplicationDelegate {
     private var permissionPollTimer: Timer?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        NSApp.appearance = NSAppearance(named: .aqua)
+        AppPreferences.applyAppearance()
         NSApp.setActivationPolicy(.accessory)
 
         MenuBarPopoverController.shared.setup()

--- a/Sources/Models/AppPreferences.swift
+++ b/Sources/Models/AppPreferences.swift
@@ -1,8 +1,10 @@
 import Foundation
+import AppKit
 import SwiftUI
 
 enum AppPreferences {
     // MARK: - Keys
+    private static let appearanceKey = "bs_appAppearance"
     private static let saveDirKey = "bs_saveDirectory"
     private static let copyAfterSaveKey = "bs_copyAfterSave"
     private static let playSoundKey = "bs_playSound"
@@ -11,6 +13,21 @@ enum AppPreferences {
     private static let exportFormatKey = "bs_exportFormat"
     private static let exportQualityKey = "bs_exportQuality"
     private static let selfTimerKey = "bs_selfTimerDelay"
+
+    // MARK: - Appearance
+    static var appearance: AppAppearance {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: appearanceKey),
+                  let appearance = AppAppearance(rawValue: raw) else { return .system }
+            return appearance
+        }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: appearanceKey) }
+    }
+
+    @MainActor
+    static func applyAppearance() {
+        NSApp.appearance = appearance.nsAppearance
+    }
 
     // MARK: - General
     static var saveDirectory: String {
@@ -90,6 +107,30 @@ enum AppPreferences {
 }
 
 // MARK: - Enums
+
+enum AppAppearance: String, CaseIterable, Identifiable {
+    case system
+    case light
+    case dark
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .system: return "System"
+        case .light: return "Light"
+        case .dark: return "Dark"
+        }
+    }
+
+    var nsAppearance: NSAppearance? {
+        switch self {
+        case .system: return nil
+        case .light: return NSAppearance(named: .aqua)
+        case .dark: return NSAppearance(named: .darkAqua)
+        }
+    }
+}
 
 enum OverlayPosition: String, CaseIterable, Codable {
     case bottomRight = "bottomRight"

--- a/Sources/Settings/PreferencesView.swift
+++ b/Sources/Settings/PreferencesView.swift
@@ -57,6 +57,7 @@ struct PreferencesView: View {
 // MARK: - General
 
 struct GeneralSettingsTab: View {
+    @AppStorage("bs_appAppearance") private var appAppearanceRaw: String = AppAppearance.system.rawValue
     @AppStorage("bs_saveDirectory") private var saveDir = NSHomeDirectory() + "/Desktop"
     @AppStorage("bs_copyAfterSave") private var copyAfterSave = true
     @AppStorage("bs_playSound") private var playSound = true
@@ -69,6 +70,16 @@ struct GeneralSettingsTab: View {
         Binding(
             get: { ExportFormat(rawValue: exportFormatRaw) ?? .png },
             set: { exportFormatRaw = $0.rawValue }
+        )
+    }
+
+    private var appAppearance: Binding<AppAppearance> {
+        Binding(
+            get: { AppAppearance(rawValue: appAppearanceRaw) ?? .system },
+            set: { newValue in
+                appAppearanceRaw = newValue.rawValue
+                AppPreferences.applyAppearance()
+            }
         )
     }
 
@@ -101,6 +112,15 @@ struct GeneralSettingsTab: View {
                 }
 
                 Toggle("Copy to clipboard after saving", isOn: $copyAfterSave)
+            }
+
+            Section("Appearance") {
+                Picker("Mode", selection: appAppearance) {
+                    ForEach(AppAppearance.allCases) { appearance in
+                        Text(appearance.label).tag(appearance)
+                    }
+                }
+                .pickerStyle(.segmented)
             }
 
             Section("Capture") {
@@ -163,6 +183,8 @@ struct GeneralSettingsTab: View {
 
             Section {
                 Button("Reset All General Settings to Defaults") {
+                    appAppearanceRaw = AppAppearance.system.rawValue
+                    AppPreferences.applyAppearance()
                     saveDir = NSHomeDirectory() + "/Desktop"
                     copyAfterSave = true
                     playSound = true


### PR DESCRIPTION
## Summary
- Add a General > Appearance setting with System, Light, and Dark modes
- Apply the saved app appearance at launch instead of forcing light mode
- Update the app appearance immediately when the setting changes

## Testing
- `make build`
- Manually verified System, Light, and Dark modes in the local app