### PR TITLE
feat: add option to automatically open editor after screenshot

### DIFF
--- a/Sources/Capture/CaptureOrchestrator.swift
+++ b/Sources/Capture/CaptureOrchestrator.swift
@@ -142,7 +142,16 @@ final class CaptureOrchestrator {
             )
         }
 
-        PreviewOverlay.shared.show(url: displayURL, on: captureScreen)
+        if AppPreferences.openEditorAfterCapture {
+            let ext = displayURL.pathExtension.lowercased()
+            if ext == "mov" || ext == "mp4" {
+                VideoEditorWindowController.shared.open(url: displayURL, on: captureScreen)
+            } else {
+                EditorWindowController.shared.open(url: displayURL, on: captureScreen)
+            }
+        } else {
+            PreviewOverlay.shared.show(url: displayURL, on: captureScreen)
+        }
     }
 
     private func saveImage(_ cgImage: CGImage) -> URL? {

--- a/Sources/Models/AppPreferences.swift
+++ b/Sources/Models/AppPreferences.swift
@@ -17,6 +17,7 @@ enum AppPreferences {
     private static let recordingShowCursorKey = "bs_recordingShowCursor"
     private static let recordingCaptureAudioKey = "bs_recordingCaptureAudio"
     private static let recordingOpenEditorKey = "bs_recordingOpenEditor"
+    private static let openEditorAfterCaptureKey = "bs_openEditorAfterCapture"
 
     // MARK: - Appearance
     static var appearance: AppAppearance {
@@ -116,6 +117,12 @@ enum AppPreferences {
     static var recordingOpenEditor: Bool {
         get { UserDefaults.standard.object(forKey: recordingOpenEditorKey) as? Bool ?? true }
         set { UserDefaults.standard.set(newValue, forKey: recordingOpenEditorKey) }
+    }
+
+    // MARK: - Screenshot
+    static var openEditorAfterCapture: Bool {
+        get { UserDefaults.standard.object(forKey: openEditorAfterCaptureKey) as? Bool ?? false }
+        set { UserDefaults.standard.set(newValue, forKey: openEditorAfterCaptureKey) }
     }
 
     // MARK: - Default Beautifier Config

--- a/Sources/Settings/PreferencesView.swift
+++ b/Sources/Settings/PreferencesView.swift
@@ -562,6 +562,7 @@ struct CaptureSettingsTab: View {
     @AppStorage("bs_selfTimerDelay") private var selfTimerRaw: Int = 0
     @AppStorage("bs_overlayPosition") private var overlayPositionRaw: String = OverlayPosition.bottomRight.rawValue
     @AppStorage("bs_overlayDismissDelay") private var overlayDismissDelay: Double = 5.0
+    @AppStorage("bs_openEditorAfterCapture") private var openEditorAfterCapture = false
     @State private var shortcutResetID = UUID()
 
     private var selfTimerDelay: Binding<SelfTimerDelay> {
@@ -606,6 +607,14 @@ struct CaptureSettingsTab: View {
                     .controlSize(.small)
             }
 
+            Section("After Capture") {
+                Toggle("Open editor automatically", isOn: $openEditorAfterCapture)
+
+                Text("When enabled, the annotation editor opens immediately after taking a screenshot.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Keyboard Shortcuts") {
                 VStack(alignment: .leading, spacing: 8) {
                     ShortcutRow(label: "Region", action: .region)
@@ -641,6 +650,7 @@ struct CaptureSettingsTab: View {
                     selfTimerRaw = 0
                     overlayPositionRaw = OverlayPosition.bottomRight.rawValue
                     overlayDismissDelay = 5.0
+                    openEditorAfterCapture = false
                     for action in ShortcutService.Action.allCases {
                         let def: ShortcutService.Shortcut? = switch action {
                         case .region: .defaultRegion


### PR DESCRIPTION
Adds a toggle in **Settings → Capture → After Capture** to automatically open the annotation editor immediately after taking a screenshot, skipping the preview overlay.

### Changes

| File | Change |
|---|---|
| `AppPreferences.swift` | Added `openEditorAfterCapture` preference (`Bool`, defaults to `false`) |
| `PreferencesView.swift` | Added "Open editor automatically" toggle in Capture settings tab, included in reset-defaults |
| `CaptureOrchestrator.swift` | When preference is enabled, opens the editor directly (`EditorWindowController` or `VideoEditorWindowController` based on file type) instead of showing the preview overlay |

### Behavior

- **Disabled (default)** — Existing behavior: screenshot saves → preview overlay appears → user clicks to open editor
- **Enabled** — Screenshot saves → editor opens immediately, no preview overlay
