### PR TITLE
fix: invalidate the update download URLSession

### DIFF
--- a/Sources/Services/AppUpdater.swift
+++ b/Sources/Services/AppUpdater.swift
@@ -137,7 +137,14 @@ final class AppUpdater {
             }
         }
 
+        // A delegate-based URLSession keeps a strong reference to its delegate until it is
+        // invalidated, so the session and the delegate outlive every download otherwise.
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        defer {
+            session.finishTasksAndInvalidate()
+            self.downloadTask = nil
+        }
+
         let downloadTask = session.downloadTask(with: url)
         self.downloadTask = downloadTask
 


### PR DESCRIPTION
### Problem

`downloadAndInstall(version:url:)` creates a delegate-based `URLSession` and never invalidates it:

https://github.com/KartikLabhshetwar/better-shot/blob/main/Sources/Services/AppUpdater.swift#L140

`URLSession` keeps a **strong** reference to its delegate until `finishTasksAndInvalidate()` or `invalidateAndCancel()` is called — this is documented behaviour, not an ARC cycle, so the session, the `DownloadProgressDelegate` and its captured closures stay alive for the rest of the process lifetime. Every update download leaks one more set.

### Fix

Invalidate the session on every exit path from `downloadAndInstall` and drop the finished task reference.

### Verification

`swiftc -typecheck` over `Sources/` with `-swift-version 6` passes with no new errors or warnings (no Xcode on this machine, so no full build). The change is confined to resource release, no behavioural change to the download or install flow.
