### PR TITLE
fix: release the previous AVPlayer time observer when loading a video

### DIFF
--- a/Sources/Recording/VideoEditorModel.swift
+++ b/Sources/Recording/VideoEditorModel.swift
@@ -37,6 +37,10 @@ final class VideoEditorModel {
     var formattedDuration: String { formatTime(trimmedDuration) }
 
     func loadVideo(from url: URL) {
+        // Detach from the outgoing player before it is replaced — a periodic time observer
+        // can only be removed by the AVPlayer that vended it.
+        removeTimeObserver()
+
         let resolvedURL: URL
         if let record = HistoryStore.shared.records.first(where: {
             $0.beautifiedPath != nil && URL(fileURLWithPath: $0.beautifiedPath!) == url
@@ -304,17 +308,21 @@ final class VideoEditorModel {
 
     func cleanup() {
         player?.pause()
-        if let observer = timeObserver {
-            player?.removeTimeObserver(observer)
-        }
-        timeObserver = nil
+        removeTimeObserver()
         player = nil
     }
 
     // MARK: - Private
 
+    private func removeTimeObserver() {
+        guard let observer = timeObserver else { return }
+        player?.removeTimeObserver(observer)
+        timeObserver = nil
+    }
+
     private func setupTimeObserver() {
         guard let player else { return }
+        removeTimeObserver()
         let interval = CMTime(value: 1, timescale: 30)
         timeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] time in
             Task { @MainActor in


### PR DESCRIPTION
### Problem

`VideoEditorModel.setupTimeObserver()` assigns `timeObserver` without removing the previous one:

https://github.com/KartikLabhshetwar/better-shot/blob/main/Sources/Recording/VideoEditorModel.swift#L317

`loadVideo(from:)` also replaces `player` outright. Opening a second recording in the same editor model therefore strands the old periodic observer together with the `AVPlayer` it was installed on — the observer keeps firing against a player nobody can reach any more, and neither is ever released. `cleanup()` only ever removes the observer of the *current* player.

### Fix

Add `removeTimeObserver()` and call it:

- at the top of `loadVideo(from:)`, while the old player is still around (a periodic time observer can only be removed by the `AVPlayer` that vended it, so ordering matters here);
- before installing a new observer;
- from `cleanup()`, which now shares the same path.

### Verification

`swiftc -typecheck` over `Sources/` with `-swift-version 6` passes with no new errors or warnings (no Xcode on this machine, so no full build).
