### PR TITLE
perf: downsample the capture preview thumbnail

### DIFF
--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -205,8 +205,26 @@ struct PreviewCardView: View {
                 }
             }
         } else {
-            thumbnail = NSImage(contentsOf: url)
+            Task.detached {
+                let image = Self.downsampledImage(at: url, maxPixelSize: 260)
+                await MainActor.run { thumbnail = image }
+            }
         }
+    }
+
+    /// Decodes a thumbnail-sized image instead of the full capture: a 5K screenshot costs
+    /// ~60 MB decoded, and the card only ever shows it at 130x98 points.
+    nonisolated private static func downsampledImage(at url: URL, maxPixelSize: CGFloat) -> NSImage? {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
+
+        let options: [CFString: Any] = [
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+        ]
+
+        guard let thumb = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else { return nil }
+        return NSImage(cgImage: thumb, size: NSSize(width: thumb.width, height: thumb.height))
     }
 
     @ViewBuilder
@@ -265,7 +283,12 @@ struct PreviewCardView: View {
                 pillButton("Copy") {
                     let pb = NSPasteboard.general
                     pb.clearContents()
-                    pb.writeObjects([image])
+                    // The card holds a downsampled thumbnail — copy the capture itself.
+                    if let url = overlay.currentURL, let fullSize = NSImage(contentsOf: url) {
+                        pb.writeObjects([fullSize])
+                    } else {
+                        pb.writeObjects([image])
+                    }
                     overlay.dismiss()
                 }
                 pillButton("Save") {


### PR DESCRIPTION
### Problem

The floating preview card decodes the **full-size** screenshot on the main actor after every capture:

https://github.com/KartikLabhshetwar/better-shot/blob/main/Sources/Preview/PreviewOverlay.swift#L208

`NSImage(contentsOf:)` decodes the whole bitmap. A 5K screenshot is roughly 60 MB decoded — allocated and decoded on the main thread, at the exact moment the capture pipeline is already busy rendering and writing the beautified PNG — for a card that is drawn at 130x98 points.

The video branch right above it already does the right thing (bounded `maximumSize`, off the main actor).

### Fix

- Decode a 260 px thumbnail with `CGImageSourceCreateThumbnailAtIndex` inside a detached task. This is the same approach `HistoryStore.thumbnail(for:)` already uses, so no new dependency or pattern is introduced.
- The hover **Copy** button used to put that full-size `NSImage` on the pasteboard, so it now re-reads the file — the clipboard still receives the full-resolution image, not the thumbnail. Drag-and-drop was already URL-based and is unaffected.

### Verification

`swiftc -typecheck` over `Sources/` with `-swift-version 6` passes with no new errors or warnings (no Xcode on this machine, so no full build). Worth a quick manual check of the Copy button in the preview card if you want belt and braces.
