### PR TITLE
perf: decode history thumbnails off the main actor

### DIFF
--- a/Sources/History/HistoryStore.swift
+++ b/Sources/History/HistoryStore.swift
@@ -93,14 +93,22 @@ final class HistoryStore {
         return urlForRecord(record)
     }
 
-    func thumbnail(for record: CaptureRecord, maxSize: CGFloat = 120) -> NSImage? {
-        let url = displayURLForRecord(record)
+    /// What `decodeThumbnail` needs, resolved on the main actor before the decode is handed off.
+    struct ThumbnailSource: Sendable {
+        let url: URL
+        let kind: CaptureKind
+    }
 
-        if record.kind == .recording {
-            return videoThumbnail(url: url, maxSize: maxSize)
+    func thumbnailSource(for record: CaptureRecord) -> ThumbnailSource {
+        ThumbnailSource(url: displayURLForRecord(record), kind: record.kind)
+    }
+
+    nonisolated static func decodeThumbnail(_ source: ThumbnailSource, maxSize: CGFloat = 120) -> NSImage? {
+        if source.kind == .recording {
+            return videoThumbnail(url: source.url, maxSize: maxSize)
         }
 
-        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
+        guard let imageSource = CGImageSourceCreateWithURL(source.url as CFURL, nil) else { return nil }
 
         let options: [CFString: Any] = [
             kCGImageSourceThumbnailMaxPixelSize: maxSize,
@@ -108,11 +116,11 @@ final class HistoryStore {
             kCGImageSourceCreateThumbnailWithTransform: true,
         ]
 
-        guard let thumb = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else { return nil }
+        guard let thumb = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, options as CFDictionary) else { return nil }
         return NSImage(cgImage: thumb, size: NSSize(width: thumb.width, height: thumb.height))
     }
 
-    nonisolated func videoThumbnail(url: URL, maxSize: CGFloat = 120) -> NSImage? {
+    nonisolated static func videoThumbnail(url: URL, maxSize: CGFloat = 120) -> NSImage? {
         let asset = AVURLAsset(url: url)
         let generator = AVAssetImageGenerator(asset: asset)
         generator.appliesPreferredTrackTransform = true

--- a/Sources/Settings/PreferencesView.swift
+++ b/Sources/Settings/PreferencesView.swift
@@ -1012,8 +1012,9 @@ struct HistoryTab: View {
     }
 
     private func loadThumbnail(for record: CaptureRecord) {
+        let source = HistoryStore.shared.thumbnailSource(for: record)
         Task.detached {
-            let thumb = await HistoryStore.shared.thumbnail(for: record, maxSize: 80)
+            let thumb = HistoryStore.decodeThumbnail(source, maxSize: 80)
             await MainActor.run {
                 if let thumb {
                     thumbnails[record.id.uuidString] = thumb
@@ -1119,8 +1120,9 @@ struct VideosTab: View {
     }
 
     private func loadThumbnail(for record: CaptureRecord) {
+        let source = HistoryStore.shared.thumbnailSource(for: record)
         Task.detached {
-            let thumb = await HistoryStore.shared.thumbnail(for: record, maxSize: 80)
+            let thumb = HistoryStore.decodeThumbnail(source, maxSize: 80)
             await MainActor.run {
                 if let thumb {
                     thumbnails[record.id.uuidString] = thumb


### PR DESCRIPTION
### Problem

The History and Videos tabs look like they load thumbnails in the background, but they do not:

https://github.com/KartikLabhshetwar/better-shot/blob/main/Sources/Settings/PreferencesView.swift#L1015

`HistoryStore` is `@MainActor`, so `await HistoryStore.shared.thumbnail(for:)` hops straight back onto the main actor and runs the `CGImageSource` decode there. For recordings it is worse: `AVAssetImageGenerator.copyCGImage` is a synchronous decode of a video frame, also on the main thread. The `Task.detached` wrapper buys nothing.

### Fix

Split the two halves that have different isolation requirements:

- `thumbnailSource(for:)` stays on the main actor and only resolves the record's URL and kind (cheap, no I/O beyond an existence check).
- `decodeThumbnail(_:maxSize:)` is a `nonisolated static` function that does the actual decoding, so it runs on whatever executor calls it — the detached task in the two `loadThumbnail` call sites.

`videoThumbnail(url:maxSize:)` becomes `nonisolated static` for the same reason; it had no reason to be an instance method.

### Verification

`swiftc -typecheck` over `Sources/` with `-swift-version 6` passes with no new errors or warnings (no Xcode on this machine, so no full build). Both call sites of the old `thumbnail(for:)` are updated; `grep` shows no other users.
