### PR TITLE
fix: keep the chosen annotation tool armed after a shape is committed

### DIFF
--- a/Sources/BetterShot/AnnoEditorInteraction.swift
+++ b/Sources/BetterShot/AnnoEditorInteraction.swift
@@ -241,9 +241,6 @@ extension AnnoEditor {
                 setBoxSize(id, width: fallback, height: fallback)
             }
             selectedIds = [id]
-            // Redaction is repetitive by nature: one screenshot usually has several fields to
-            // hide, so blur and pixelate stay armed instead of dropping back to select.
-            if !tool.isRedactionTool { tool = .select }
 
         case let .creatingArrow(id):
             if let shape = document.shape(id), let props = shape.arrowProps,
@@ -252,7 +249,6 @@ extension AnnoEditor {
                 document.delete([id])
             } else {
                 selectedIds = [id]
-                tool = .select
             }
 
         case let .brushing(origin):
@@ -677,10 +673,6 @@ extension AnnoEditor {
             selectedIds.remove(id)
         }
         onEditingTextChanged?(nil)
-        // Fall back to select once the text is committed, the same as finishing a geo or an arrow.
-        // Safe against the `tool` observer calling back into here: `editingTextId` is already nil,
-        // so the guard at the top returns immediately.
-        if tool == .text { tool = .select }
         notifyChanged()
     }
 

--- a/Sources/BetterShot/AnnoEditorInteraction.swift
+++ b/Sources/BetterShot/AnnoEditorInteraction.swift
@@ -241,7 +241,9 @@ extension AnnoEditor {
                 setBoxSize(id, width: fallback, height: fallback)
             }
             selectedIds = [id]
-            tool = .select
+            // Redaction is repetitive by nature: one screenshot usually has several fields to
+            // hide, so blur and pixelate stay armed instead of dropping back to select.
+            if !tool.isRedactionTool { tool = .select }
 
         case let .creatingArrow(id):
             if let shape = document.shape(id), let props = shape.arrowProps,


### PR DESCRIPTION
Closes #106.

### Problem

Committing a shape resets the tool to Select. Hiding four fields on one screenshot means picking Blur four times, and drawing three rectangles means picking Rectangle three times. A tool picked by hand should stay picked until another one is picked.

### Cause

Three separate reset points, all doing the same thing:

- [`AnnoEditorInteraction.swift#L244`](https://github.com/KartikLabhshetwar/better-shot/blob/v0.4.0/Sources/BetterShot/AnnoEditorInteraction.swift#L244) — the `.creatingGeo` branch, which `beginBoxShape` feeds from `.rectangle, .filledRectangle, .ellipse, .highlight, .blur, .pixelate`.
- [`AnnoEditorInteraction.swift#L253`](https://github.com/KartikLabhshetwar/better-shot/blob/v0.4.0/Sources/BetterShot/AnnoEditorInteraction.swift#L253) — the `.creatingArrow` branch, for line and arrow.
- [`AnnoEditorInteraction.swift#L681`](https://github.com/KartikLabhshetwar/better-shot/blob/v0.4.0/Sources/BetterShot/AnnoEditorInteraction.swift#L681) — `stopEditingText`, for text.

Freehand and numbered circle never touch `tool`, so two of the eleven tools already behave the way this PR makes the rest behave.

### Change

All three go away. The diff is three deletions and a stale comment.

`selectAll()` still forces Select ([`AnnoEditor.swift#L281`](https://github.com/KartikLabhshetwar/better-shot/blob/v0.4.0/Sources/BetterShot/AnnoEditor.swift#L281)) — that one is deliberate, since there is nothing to draw with a whole document selected, and it stays.

I opened this as redaction-only first, then widened it: the same reset is just as annoying for rectangles, and a rule with an exception list is harder to predict than "the tool stays until you change it". Both commits are on the branch if the narrow version is preferable — the first one is `if !tool.isRedactionTool { tool = .select }` and nothing else.

### What this changes downstream

- **The new shape stays selected.** `selectedIds = [id]` is untouched, so the inspector keeps showing the new shape's style and edits there still apply to it — draw a rectangle, change the colour, the rectangle changes.
- **Handles are not drawn for it.** The selection frame is gated on `tool == .select` ([`AnnoCanvasLayerView.swift#L197`](https://github.com/KartikLabhshetwar/better-shot/blob/v0.4.0/Sources/BetterShot/AnnoCanvasLayerView.swift#L197)), so reshaping a just-drawn box now means a trip to Select (`H`) instead of grabbing a handle straight away. That is the real trade in this PR. `createNumberedCircle` has always committed into exactly this state — selection set, tool left armed — so it is not a new combination for the engine.
- **The tool observer does not fire.** The `didSet` that clears the selection is guarded on `tool != oldValue` ([`AnnoEditor.swift#L121-L127`](https://github.com/KartikLabhshetwar/better-shot/blob/v0.4.0/Sources/BetterShot/AnnoEditor.swift#L121-L127)), and the tool no longer changes. Picking any other tool clears it exactly as today.
- **Text behaves differently now, and it is worth a look.** With the reset gone, clicking empty canvas while a text box is being edited commits that box and starts a new one, where before it committed and dropped to Select. An empty box is still deleted on commit, so this cannot pile up junk, but it is the one place where "the tool stays armed" changes more than a toolbar highlight. Easy to keep the old text behaviour by restoring just that line if you would rather.

### Verification

No Xcode on this machine (Command Line Tools only), so no `make build`. Type-checked all of `Sources/` with the project's own Swift settings from `project.yml` — `-swift-version 5 -default-isolation MainActor`, the four `SWIFT_APPROACHABLE_CONCURRENCY` features, `MemberImportVisibility`, `-target arm64-apple-macosx26.0` — against a stub of the one SPM dependency: 0 errors, and the project's existing 118 warnings are byte-identical with and without the patch.

Manual pass still needed on a machine with Xcode:

- Several blurs, then several rectangles, then several arrows, each without returning to the toolbar.
- The inspector still edits the last shape drawn (colour, stroke, Strength).
- `H` and the toolbar still leave the armed tool; `Cmd+A` still forces Select.
- Text: type a box, click empty canvas, confirm the first box committed and the second one opened; press Escape or `H` to leave text mode.
- Undo after a run of shapes steps back one shape at a time.
