### PR TITLE
fix: let space switch region capture to window selection

### DIFF
--- a/Sources/Capture/ScreenCapture.swift
+++ b/Sources/Capture/ScreenCapture.swift
@@ -34,7 +34,10 @@ final class ScreenCapture {
         defer { isCapturing = false }
 
         let tempPath = makeTempPath()
-        let success = await runScreencapture(["-s", "-x", "-t", "png", tempPath])
+        // -s is "only allow mouse selection mode", so space cannot reach window selection. -i is the
+        // mode that carries the toggle, -J pins the starting mode because -i alone reopens in
+        // whichever one was used last, and -o matches captureWindow's shadowless window shot.
+        let success = await runScreencapture(["-i", "-J", "selection", "-o", "-x", "-t", "png", tempPath])
         guard success, FileManager.default.fileExists(atPath: tempPath) else { return nil }
         return URL(fileURLWithPath: tempPath)
     }


### PR DESCRIPTION
Closes #107.

### Problem

Pressing space during a region capture does nothing. In the system screenshot tool space toggles between mouse selection and window selection, and BetterShot's region capture looks like it should do the same.

### Cause

`captureRegion` shells out with `-s`:

https://github.com/KartikLabhshetwar/better-shot/blob/v0.4.0/Sources/Capture/ScreenCapture.swift#L37

`man screencapture` defines `-s` as "only allow mouse selection mode". The space toggle belongs to `-i`, "capture screen interactively, by selection or window", where "the space key will toggle between mouse selection and window selection modes". So the key is not being swallowed by anything — the mode it switches to was never enabled.

One note on the issue text: #107 describes this as a regression, but as far as I can tell the fix never actually shipped. #104 proposed exactly this change and was closed unmerged, `-s` is what every revision of `ScreenCapture.swift` in the history has, and no release carries it in the changelog. So this is the change landing for the first time rather than a break in 0.4.0.

### Change

```swift
["-i", "-J", "selection", "-o", "-x", "-t", "png", tempPath]
```

- `-i` enables the interactive mode that carries the space toggle. Escape still cancels, and a cancelled capture writes no file, which the existing `FileManager.fileExists` guard already treats as a no-op.
- `-J selection` pins the starting mode. `-i` on its own reopens in whichever mode was used last, which would leave a shortcut named "Capture Region" starting in window mode after one space press.
- `-o` drops the window shadow, so a space-switched shot matches what `captureWindow` produces, which passes `-o` through its `includeShadow: false` default.
- `-x` and `-t png` are unchanged.

`captureAndOCR` goes through `captureRegion`, so OCR gets the window toggle as well.

### Adjacent, not touched

`AppPreferences.captureWindowShadow` exists in `BetterShotPreferences.swift` but has no readers — `captureWindow()` is only ever called with its default, so the preference cannot affect a capture today. That looked out of scope for this fix; happy to file it separately if it is worth wiring up.

### Verification

No Xcode on this machine (Command Line Tools only), so no `make build`. Verified the flag semantics against `man screencapture` on macOS 26, and type-checked all of `Sources/` with the project's own Swift settings from `project.yml` — `-swift-version 5 -default-isolation MainActor`, the four `SWIFT_APPROACHABLE_CONCURRENCY` features, `MemberImportVisibility`, `-target arm64-apple-macosx26.0` — against a stub of the one SPM dependency: 0 errors, and the project's existing 118 warnings are byte-identical with and without the patch.

Manual pass still needed on a machine with Xcode:

- Region capture starts in crosshair mode, space switches to window highlight, space switches back.
- A space-switched shot has no drop shadow, like Capture Window.
- Escape still cancels without leaving a file or an error.
- A second region capture still starts in crosshair mode after the previous one ended in window mode.
- OCR capture behaves the same way.
