### PR TITLE
feat: bring back the editor's Copy button

### DIFF
--- a/Sources/BetterShot/AnnotationEditorWindow.swift
+++ b/Sources/BetterShot/AnnotationEditorWindow.swift
@@ -18,6 +18,8 @@ struct AnnotationEditorWindow: View {
     @State private var isInspectorPresented = true
     @State private var isSaving = false
     @State private var saveFlash = false
+    @State private var isCopying = false
+    @State private var copyFlash = false
     @State private var isUploading = false
     @State private var uploadItemID: UUID?
     @State private var closeGuard = EditorCloseGuard()
@@ -186,6 +188,22 @@ struct AnnotationEditorWindow: View {
             }
         }
 
+        Button(action: copyToClipboard) {
+            if isCopying {
+                ProgressView().controlSize(.small)
+            } else if copyFlash {
+                Label("Copied", systemImage: "checkmark.circle.fill")
+                    .labelStyle(.titleAndIcon)
+                    .foregroundStyle(.green)
+            } else {
+                Label("Copy", systemImage: "doc.on.doc")
+                    .labelStyle(.titleAndIcon)
+            }
+        }
+        .keyboardShortcut("c", modifiers: [.command, .shift])
+        .disabled(model.previewImage == nil || model.imageSize == .zero || isCopying)
+        .help("Copy the finished image to the clipboard (⇧⌘C)")
+
         Button(action: exportImage) {
             Label("Export", systemImage: "arrow.down.circle")
                 .labelStyle(.titleAndIcon)
@@ -329,6 +347,42 @@ struct AnnotationEditorWindow: View {
     private func closeAfterLoadFailure() {
         model.releaseEditorResources()
         dismissWindow()
+    }
+
+    /// The clipboard route out of the editor: renders the current edits and hands
+    /// them straight to the pasteboard, so a screenshot meant for a chat message
+    /// costs no save panel and leaves no file to hunt down afterwards.
+    private func copyToClipboard() {
+        clearInspectorFocus()
+        guard let sourceURL = model.sourceURL, !isCopying else { return }
+        let baseURL = model.baseImageURL ?? sourceURL
+
+        isCopying = true
+        Task {
+            defer { isCopying = false }
+            do {
+                let renderedURL = try await AnnotationRenderer.renderToTemporaryFileInBackground(
+                    sourceURL: baseURL,
+                    shapes: model.shapes,
+                    backgroundSettings: model.backgroundSettings
+                )
+                // The render stays on disk: copyPNGToClipboard offers it as a file
+                // reference too, which is what lets terminals and Slack paste it,
+                // and that flavor is only good for as long as the file is.
+                try ScreenshotFileActions.copyPNGToClipboard(from: renderedURL)
+                flashCopyConfirmation()
+            } catch {
+                model.errorMessage = "Failed to copy annotation: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    private func flashCopyConfirmation() {
+        withAnimation(.snappy(duration: 0.2)) { copyFlash = true }
+        Task {
+            try? await Task.sleep(for: .milliseconds(1400))
+            withAnimation(.snappy(duration: 0.2)) { copyFlash = false }
+        }
     }
 
     private func exportImage() {


### PR DESCRIPTION
Closes #110.

### Problem

The image editor lost its Copy button in the 0.4.0 toolbar rebuild. An annotated screenshot can now only leave the editor through Export, which opens an `NSSavePanel`, or through Save, which files it away in history. Both write a file for something that was only ever going to be pasted into a chat.

### Change

The button comes back where it was on 0.3.x — in the trailing toolbar group, immediately left of Export — on its old ⇧⌘C shortcut, with the same `doc.on.doc` icon.

It renders through `AnnotationRenderer.renderToTemporaryFileInBackground`, the same call `commitEdits` uses, so the clipboard gets exactly what Save and Export would produce: annotations, background, crop and all. Nothing is committed to history and no save panel appears.

The pasteboard write goes through `ScreenshotFileActions.copyPNGToClipboard`, which was already sitting in `BetterShotPreferences.swift` without a single caller anywhere in `Sources/`. It is a better clipboard write than the one 0.3.x had: the old `copyToClipboard` wrote an `NSImage` and nothing else, while this one puts the file reference, the image data and TIFF on a single pasteboard item, which is what makes a paste work in a terminal or Slack rather than only in Gmail — the reasoning is spelled out in the comment already on that function.

Feedback matches the toolbar's existing vocabulary: a spinner while rendering, then a green "Copied" that fades after 1.4s, mirroring `saveFlash` and the Share button's "Link Copied".

### Two deliberate details

- **The rendered file is left in the temporary directory.** `copyPNGToClipboard` advertises a `.fileURL` flavor, and that flavor is only valid while the file exists, so deleting it right after the copy would break exactly the terminal-paste case the function was written for. The file lands in `NSTemporaryDirectory()` under the `BetterShot_Annotated_` prefix `renderToTemporaryFile` already uses, and the system reclaims it.
- **The clipboard copy is always PNG**, regardless of the export format preference. JPEG on a clipboard costs quality for no benefit and cannot carry the alpha a transparent screenshot may have. `copyPNGToClipboard` exists for exactly this, next to the format-aware `copyImageToClipboard`.

### Verification

No Xcode on this machine (Command Line Tools only), so no `make build`. Type-checked all of `Sources/` with the project's own Swift settings from `project.yml` — `-swift-version 5 -default-isolation MainActor`, the four `SWIFT_APPROACHABLE_CONCURRENCY` features, `MemberImportVisibility`, `-target arm64-apple-macosx26.0` — against a stub of the one SPM dependency: 0 errors, and the project's existing 118 warnings are byte-identical with and without the patch.

Manual pass still needed on a machine with Xcode:

- Annotate a screenshot, press Copy, paste into Mail or Notes — annotations present.
- Paste the same clipboard into a terminal and into Slack — should arrive as a file, not fail.
- Copy an untouched screenshot straight after opening the editor.
- Copy one with a background and a crop applied, confirm the paste matches Export.
- ⇧⌘C with focus in an inspector text field, and confirm `C` alone still toggles crop.
- The button disables while a render is in flight and re-enables after the flash.
