### PR TITLE
perf: stop re-decoding the studio wallpaper on every preview frame

### DIFF
--- a/Sources/BetterShot/RecordingStudioWindow.swift
+++ b/Sources/BetterShot/RecordingStudioWindow.swift
@@ -1062,13 +1062,7 @@ private struct StudioBackgroundView: View {
                 endPoint: gradient.endPoint
             )
         case .customWallpaper(let wallpaper):
-            if let image = NSImage(contentsOf: wallpaper.url) {
-                Image(nsImage: image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-            } else {
-                Color(white: 0.04)
-            }
+            AnnotationCustomWallpaperPreview(wallpaper: wallpaper, maxPixelSize: 2048)
         }
     }
 }


### PR DESCRIPTION
Closes #112.

### Problem

`StudioBackgroundView` decoded the wallpaper inside its `body` (`RecordingStudioWindow.swift:1064`), and that view sits inside the 60 Hz `TimelineView` that drives the preview canvas (`RecordingStudioWindow.swift:392`). So with a custom wallpaper set, every frame of playback read the file from disk and built a fresh `NSImage`. A new object each time means no decoded bitmap is ever reused, and a 5–6K desktop wallpaper is tens of megabytes decoded — on the main thread, in the same tick that has to draw the video frame. Scrubbing paid the same cost per mouse move.

### Change

The wallpaper case now renders `AnnotationCustomWallpaperPreview`, which is what the image editor's `AnnotationBackgroundStageFill` (`AnnotationBackgroundPreviewViews.swift:28`) already uses for this exact style — same component, same 2048 px budget. It keeps the image in `@State` and loads it through `AnnotationWallpaperPreviewCache` with `.task(id: cacheID)`, so the decode happens once, off the main actor, and re-runs only when the file itself changes. The cache is an actor with a 48-entry `NSCache` and in-flight deduplication, so the studio and the editor share entries when both show the same wallpaper at the same budget.

Net effect: seven lines out, one line in. The other three cases in the switch are untouched — solid and gradient were always cheap SwiftUI views.

### Behaviour differences worth knowing

- **A brief loading state on first paint.** `AnnotationCustomWallpaperPreview` shows `controlBackgroundColor` with a small spinner until the first decode lands, where the old code blocked on the decode and painted the finished image. This is the same first-paint behaviour the editor already has for the same wallpaper.
- **A failed read is now visible.** An unreadable file used to fall back to `Color(white: 0.04)`, silently indistinguishable from a plain dark background. It now shows the component's black-plus-warning-triangle state, which is what the editor does. If you would rather keep it silent in the studio, that is a change inside `AnnotationCustomWallpaperPreview` rather than here.

### Verification

No Xcode on this machine (Command Line Tools only), so no `make build`. Type-checked all of `Sources/` with the project's own Swift settings from `project.yml` — `-swift-version 5 -default-isolation MainActor`, the four `SWIFT_APPROACHABLE_CONCURRENCY` features, `MemberImportVisibility`, `-target arm64-apple-macosx26.0` — against a stub of the one SPM dependency: 0 errors, and `main`'s existing 124 warnings are byte-identical with and without the patch.

Manual pass still needed on a machine with Xcode:

- Set a custom wallpaper on a recording, play the preview, and confirm the background looks the same as before and playback is smoother than it was (Instruments' time profiler on the main thread makes the difference obvious).
- Scrub the timeline with a wallpaper set.
- Switch between wallpaper, solid, gradient and none, and back.
- Change the wallpaper file on disk under the same path and confirm the preview picks up the new image (that is what the file signature in `cacheID` is for).
- Export with a wallpaper and confirm the exported frame is unchanged — export goes through `RecordingStudioExporter`, which was not touched.
