### PR TITLE
perf: decode the preview card thumbnail off the main actor

### DIFF
--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -202,7 +202,11 @@ struct PreviewCardView: View {
         )
         Task.detached(priority: .userInitiated) {
             let image = HistoryStore.decodeThumbnail(source, maxSize: 260)
-            await MainActor.run { thumbnail = image }
+            // Two captures in quick succession race: the older decode can land last
+            // and paint the previous capture onto the current card.
+            await MainActor.run {
+                if overlay.currentURL == url { thumbnail = image }
+            }
         }
     }
 

--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -1,5 +1,4 @@
 import AppKit
-import AVFoundation
 import SwiftUI
 
 /// Shows a floating preview card after capture. Uses a borderless NSPanel.
@@ -119,7 +118,12 @@ struct PreviewCardView: View {
     private let cardSize = CGSize(width: 130, height: 98)
 
     private var isVideo: Bool {
-        guard let ext = overlay.currentURL?.pathExtension.lowercased() else { return false }
+        guard let url = overlay.currentURL else { return false }
+        return Self.isVideo(url)
+    }
+
+    private static func isVideo(_ url: URL) -> Bool {
+        let ext = url.pathExtension.lowercased()
         return ext == "mov" || ext == "mp4"
     }
 
@@ -141,7 +145,7 @@ struct PreviewCardView: View {
                     }
 
                     if isHovered {
-                        hoverOverlay(image: image)
+                        hoverOverlay()
                             .transition(.opacity.animation(.easeInOut(duration: 0.15)))
                     }
                 }
@@ -188,26 +192,22 @@ struct PreviewCardView: View {
             return
         }
 
-        let ext = url.pathExtension.lowercased()
-        if ext == "mov" || ext == "mp4" {
-            Task.detached {
-                let asset = AVURLAsset(url: url)
-                let generator = AVAssetImageGenerator(asset: asset)
-                generator.appliesPreferredTrackTransform = true
-                generator.maximumSize = CGSize(width: 260, height: 196)
-                if let result = try? await generator.image(at: .zero) {
-                    let cgImage = result.image
-                    let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
-                    await MainActor.run { thumbnail = nsImage }
-                }
-            }
-        } else {
-            thumbnail = NSImage(contentsOf: url)
+        // Both kinds go through the history store's decoder: it samples a bounded
+        // thumbnail rather than the full bitmap, and it is nonisolated, so the
+        // decode runs off the main actor instead of on the tick that just
+        // finished rendering the capture.
+        let source = HistoryStore.ThumbnailSource(
+            url: url,
+            kind: Self.isVideo(url) ? .recording : .screenshot
+        )
+        Task.detached(priority: .userInitiated) {
+            let image = HistoryStore.decodeThumbnail(source, maxSize: 260)
+            await MainActor.run { thumbnail = image }
         }
     }
 
     @ViewBuilder
-    private func hoverOverlay(image: NSImage) -> some View {
+    private func hoverOverlay() -> some View {
         ZStack {
             Color.black.opacity(0.45)
                 .contentShape(Rectangle())
@@ -260,9 +260,14 @@ struct PreviewCardView: View {
             // Center pill actions
             HStack(spacing: 6) {
                 pillButton("Copy") {
-                    let pb = NSPasteboard.general
-                    pb.clearContents()
-                    pb.writeObjects([image])
+                    // Copy the capture itself, not the card's thumbnail.
+                    if let url = overlay.currentURL {
+                        if isVideo {
+                            try? VideoFileActions.copyToClipboard(from: url)
+                        } else {
+                            try? ScreenshotFileActions.copyImageToClipboard(from: url)
+                        }
+                    }
                     overlay.dismiss()
                 }
                 pillButton("Save") {


### PR DESCRIPTION
Closes #114.

### Problem

The preview card decoded the full-size screenshot on the main actor (`PreviewOverlay.swift:205`), for a card drawn at 130x98 points. A 5K shot is roughly 60 MB decoded, and the decode landed on the main thread at the moment the capture pipeline was already rendering and writing the beautified PNG. The video branch right above it already did the right thing.

This shipped once before as #92 and was lost in the 0.4.0 history rewrite — see the issue for which commits from that batch survived and which did not.

### Change

Both branches now go through `HistoryStore.decodeThumbnail(_:maxSize:)`, the `nonisolated static` decoder that #93 added and that already covers screenshots and recordings behind one `ThumbnailSource`. That collapses two branches into one and moves the decode off the main actor. 260 px matches the bound the video branch was already using.

Two call sites read the full-size image out of `thumbnail`, so they were adjusted rather than left to silently degrade:

- **Copy** wrote `thumbnail` to the pasteboard, which after this change would have been a 260 px thumbnail. It now copies the capture itself — `ScreenshotFileActions.copyImageToClipboard(from:)` for images, `VideoFileActions.copyToClipboard(from:)` for recordings. The second half is a fix in its own right: Copy on a recording used to put a still frame on the clipboard instead of the file.
- **`.onDrag`** already prefers `NSItemProvider(contentsOf: url)` and only falls back to the in-memory image. That fallback is now a thumbnail, but it is only reachable when the file was readable enough to produce a thumbnail and simultaneously not readable by `NSItemProvider`, so it is close to unreachable — left alone rather than reworked.

`import AVFoundation`, the `image` parameter on `hoverOverlay`, and the duplicated video-extension check became unused as a direct result and were removed.

### Behaviour difference

The card used to paint its image synchronously on the first frame for screenshots. It now shows the same empty state the video path always showed, for as long as the off-main decode takes. That is the trade the fix is: a few milliseconds of empty card instead of a 60 MB main-thread decode competing with the capture pipeline.

### Verification

No Xcode on this machine (Command Line Tools only), so no `make build`. Type-checked all of `Sources/` with the project's own Swift settings from `project.yml` — `-swift-version 5 -default-isolation MainActor`, the four `SWIFT_APPROACHABLE_CONCURRENCY` features, `MemberImportVisibility`, `-target arm64-apple-macosx26.0` — against a stub of the one SPM dependency: 0 errors, and `main`'s existing 124 warnings are byte-identical with and without the patch.

Manual pass still needed on a machine with Xcode:

- Take a screenshot on a 5K display and confirm the card appears promptly and the image is right way up and not stretched.
- Fire several captures in quick succession and confirm the card always shows the newest one (the stale-decode guard added in 24ee41c).
- Take a recording and confirm the card still shows the first frame with the play badge.
- Hover Copy on a screenshot, paste into Mail and into a terminal — full resolution, not 260 px.
- Hover Copy on a recording and paste into Finder or Slack — should be the video file.
- Drag the card out to Finder for both kinds.
- Delete and Save on the hover overlay, which were not touched.
