### PR TITLE
perf: read and thin the pointer sidecar off the main actor

### DIFF
--- a/Sources/BetterShot/RecordingStudioModel.swift
+++ b/Sources/BetterShot/RecordingStudioModel.swift
@@ -250,7 +250,6 @@ final class RecordingStudioModel {
 
         if let session {
             manifest = session.loadCaptureManifest()
-            pointerCapture = session.loadPointerCapture() ?? PointerCaptureFile()
         }
 
         let asset = AVURLAsset(url: screenURL)
@@ -272,18 +271,22 @@ final class RecordingStudioModel {
             return
         }
 
-        if session != nil {
+        if let session {
             let pointScale = max(manifest?.pixelScale ?? 1, 1)
-            let stream = PointerStreamSanitizer.sanitize(
-                pointerCapture,
-                options: PointerSanitizeOptions(
-                    recordingSizeInPoints: CGSize(
-                        width: videoSize.width / CGFloat(pointScale),
-                        height: videoSize.height / CGFloat(pointScale)
-                    )
-                )
+            let recordingSize = CGSize(
+                width: videoSize.width / CGFloat(pointScale),
+                height: videoSize.height / CGFloat(pointScale)
             )
-            pointerCapture = stream.sanitizedCapture
+            // The recorder writes one sample per 60 Hz tick with no thinning, so the
+            // sidecar of a long recording is megabytes of JSON and the thinning pass
+            // walks every sample. Both are pure work over Sendable values, so they
+            // run off the main actor rather than in front of the opening window.
+            pointerCapture = await Task.detached(priority: .userInitiated) {
+                PointerStreamSanitizer.sanitize(
+                    session.loadPointerCapture() ?? PointerCaptureFile(),
+                    options: PointerSanitizeOptions(recordingSizeInPoints: recordingSize)
+                ).sanitizedCapture
+            }.value
             recordedPressTimes = pointerCapture.presses
                 .filter { $0.phase == .down }
                 .map(\.time)


### PR DESCRIPTION
Closes #116.

### Problem

`RecordingStudioModel` is `@MainActor`, and `load()` did two blocking passes over the pointer sidecar there: a synchronous read plus `JSONDecoder` (`RecordingStudioModel.swift:253`), and then `PointerStreamSanitizer.sanitize`, which walks every sample (`RecordingStudioModel.swift:276`).

The sidecar is not small. The recorder samples at 60 Hz and `finish()` writes every sample through untouched — thinning happens here in the studio, not at write time. Ten minutes of recording is on the order of 36 000 `PointerTravelSample` values with full-precision `Double`s, so several megabytes of JSON, and both the decode and the thinning pass grow linearly with recording length. All of it in front of the window the user is waiting on.

### Change

Both passes moved into one `Task.detached`. Nothing needed a new annotation — everything involved was already prepared for it:

- `RecordingSession` is a `nonisolated struct: Sendable`, so it crosses into the task as-is.
- `PointerCaptureFile` is `Sendable`.
- `PointerStreamSanitizer` is a `nonisolated enum`.
- `load()` was already `async`.

The read moved down to sit next to the thinning it feeds. It has to: the sanitizer needs `recordingSizeInPoints`, which comes from `videoSize`, which is only known after `asset.load(.duration, .tracks)`. Reading it early and holding it across that await bought nothing. A side effect is that a recording which fails to open no longer reads its sidecar at all — the old code had already paid for it before hitting the error path.

`if session != nil` became `if let session` so the task can capture the value rather than reach through the actor-isolated property.

### What this does not change

- **Thinning still runs exactly once per open.** `pointerCapture` is still assigned `stream.sanitizedCapture`, so `isSanitized` is set and every later `PointerTimeline.build` keeps taking the early return inside `sanitize`. This PR moves that single pass off the main actor; it does not change how often it happens.
- **`recordedPressTimes` and `keystrokeTimeline`** are derived from the same sanitized capture, in the same order, on the main actor as before.
- **The timeline builds** (`rebuildPointerTimeline`, `rebuildViewportTimeline`) still run on the main actor. They are called synchronously from mutations — zoom-cue edits, cuts, speed changes — so moving them is a larger change with a different shape. Noted in the issue as adjacent work rather than folded in here.

### Verification

No Xcode on this machine (Command Line Tools only), so no `make build`. Type-checked all of `Sources/` with the project's own Swift settings from `project.yml` — `-swift-version 5 -default-isolation MainActor`, the four `SWIFT_APPROACHABLE_CONCURRENCY` features, `MemberImportVisibility`, `-target arm64-apple-macosx26.0` — against a stub of the one SPM dependency: 0 errors, and `main`'s existing 124 warnings are byte-identical with and without the patch. That matters here specifically, since a concurrency mistake in this change would surface as a new `#SendableClosureCaptures` or isolation warning, and none appeared.

Manual pass still needed on a machine with Xcode:

- Open a long recording (ten minutes or more, with plenty of mouse movement) in the studio and confirm the window becomes responsive sooner than before.
- Confirm the drawn cursor, its click rings and the keystroke overlay all still appear and line up with the video — that is the whole sanitized capture round-tripping correctly.
- Open a recording made with the cursor disabled, and one with no camera, to cover the paths where the sidecar is empty or absent.
- Open a recording whose file is missing or corrupt and confirm the error path still reports cleanly.
- Zoom cues synthesized on first open (`ZoomCueSynthesizer.cues(from: pointerCapture, ...)`) should be identical to before, since they read the same sanitized capture.
- Export afterwards and confirm the exported cursor matches the preview.
