### PR TITLE
fix: report a failed copy from the preview card instead of swallowing it

### DIFF
--- a/Sources/BetterShot/VideoFileActions.swift
+++ b/Sources/BetterShot/VideoFileActions.swift
@@ -86,6 +86,9 @@ enum VideoFileActions {
     static var exportContentType: UTType { VideoExportContainer.default.contentType }
 
     static func copyToClipboard(from url: URL) throws {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw CocoaError(.fileReadNoSuchFile)
+        }
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         guard pasteboard.writeObjects([url as NSURL]) else {

--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -265,14 +265,27 @@ struct PreviewCardView: View {
             HStack(spacing: 6) {
                 pillButton("Copy") {
                     // Copy the capture itself, not the card's thumbnail.
-                    if let url = overlay.currentURL {
-                        if isVideo {
-                            try? VideoFileActions.copyToClipboard(from: url)
-                        } else {
-                            try? ScreenshotFileActions.copyImageToClipboard(from: url)
-                        }
+                    guard let url = overlay.currentURL else {
+                        overlay.dismiss()
+                        return
                     }
-                    overlay.dismiss()
+                    do {
+                        if Self.isVideo(url) {
+                            try VideoFileActions.copyToClipboard(from: url)
+                        } else {
+                            try ScreenshotFileActions.copyImageToClipboard(from: url)
+                        }
+                        overlay.dismiss()
+                    } catch {
+                        // Reading the file can fail if the capture moved or was deleted
+                        // between the shot and the click. The card stays up so the copy
+                        // can be retried, or the capture dragged out instead.
+                        ToastWindow.shared.show(
+                            title: "Copy Failed",
+                            message: error.localizedDescription,
+                            systemIcon: "exclamationmark.triangle"
+                        )
+                    }
                 }
                 pillButton("Save") {
                     overlay.dismiss()

--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -13,6 +13,8 @@ final class PreviewOverlay {
     private var dismissTask: Task<Void, Never>?
     private var targetScreen: NSScreen?
 
+    var currentScreen: NSScreen? { targetScreen }
+
     private init() {}
 
     func show(url: URL, on screen: NSScreen? = nil) {
@@ -41,6 +43,11 @@ final class PreviewOverlay {
         panel = nil
         isVisible = false
         currentURL = nil
+    }
+
+    func cancelScheduledDismiss() {
+        dismissTask?.cancel()
+        dismissTask = nil
     }
 
     // MARK: - Panel Setup
@@ -280,10 +287,12 @@ struct PreviewCardView: View {
                         // Reading the file can fail if the capture moved or was deleted
                         // between the shot and the click. The card stays up so the copy
                         // can be retried, or the capture dragged out instead.
+                        overlay.cancelScheduledDismiss()
                         ToastWindow.shared.show(
                             title: "Copy Failed",
                             message: error.localizedDescription,
-                            systemIcon: "exclamationmark.triangle"
+                            systemIcon: "exclamationmark.triangle",
+                            on: overlay.currentScreen
                         )
                     }
                 }


### PR DESCRIPTION
Follow-up to #115. Two review comments landed on it after it was merged, both on the Copy button:

- https://github.com/KartikLabhshetwar/better-shot/pull/115#discussion_r3863264604
- https://github.com/KartikLabhshetwar/better-shot/pull/115#discussion_r3863264411

### The silent failure

Before #115, Copy wrote an `NSImage` that was already in memory, so it could not fail. #115 changed both branches to read the capture from disk — necessary, because the card only holds a 260 px thumbnail now — and I wrapped those reads in `try?`. A capture moved or deleted between the shot and the click therefore left the user with an empty clipboard, no message, and a card that dismissed itself as if the copy had worked. That is a worse failure mode than the one it replaced, and it is in `main` today.

The error now raises a toast:

```swift
ToastWindow.shared.show(
    title: "Copy Failed",
    message: error.localizedDescription,
    systemIcon: "exclamationmark.triangle"
)
```

which follows the "Cloud Delete Failed" toast in `PreferencesView.swift:1323`. The card also stays up on failure, so the copy can be retried or the capture dragged out instead — dismissing it was only ever right for the success path, which still dismisses as before.

### The redundant lookup

`Self.isVideo(url)` replaces the `isVideo` property inside the button. The property re-reads `overlay.currentURL` and parses the extension a second time, although `url` is bound a line above. No behavioural difference — the closure is synchronous — but the static helper was extracted in #115 for exactly this and the bound value is the one the copy actually uses. The property still has its other caller in `body`, for the play badge, and is unchanged.

### Verification

No Xcode on this machine (Command Line Tools only), so no `make build`. Type-checked all of `Sources/` with the project's own Swift settings from `project.yml` — `-swift-version 5 -default-isolation MainActor`, the four `SWIFT_APPROACHABLE_CONCURRENCY` features, `MemberImportVisibility`, `-target arm64-apple-macosx26.0` — against a stub of the one SPM dependency: 0 errors, and `main`'s existing 124 warnings are byte-identical with and without the patch.

Manual pass still needed on a machine with Xcode:

- Copy a screenshot and a recording from the card, confirm both still land on the clipboard and the card dismisses.
- Delete the capture from the save folder while the card is still up, then press Copy: expect a Copy Failed toast, the card still on screen, and a working Save or drag afterwards.
- Confirm the play badge still appears on recordings, since it reads the same predicate through the property.
