### PR TITLE
feat: make the preview-card popup size configurable

### DIFF
--- a/Sources/Models/AppPreferences.swift
+++ b/Sources/Models/AppPreferences.swift
@@ -10,6 +10,7 @@ enum AppPreferences {
     private static let playSoundKey = "bs_playSound"
     private static let overlayPositionKey = "bs_overlayPosition"
     private static let overlayDismissDelayKey = "bs_overlayDismissDelay"
+    private static let overlayCardSizeKey = "bs_overlayCardSize"
     private static let exportFormatKey = "bs_exportFormat"
     private static let exportQualityKey = "bs_exportQuality"
     private static let selfTimerKey = "bs_selfTimerDelay"
@@ -76,6 +77,15 @@ enum AppPreferences {
             return val > 0 ? val : 5.0
         }
         set { UserDefaults.standard.set(newValue, forKey: overlayDismissDelayKey) }
+    }
+
+    static var overlayCardSize: OverlayCardSize {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: overlayCardSizeKey),
+                  let size = OverlayCardSize(rawValue: raw) else { return .small }
+            return size
+        }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: overlayCardSizeKey) }
     }
 
     // MARK: - Export
@@ -199,6 +209,40 @@ enum AppAppearance: String, CaseIterable, Identifiable {
 enum OverlayPosition: String, CaseIterable, Codable {
     case bottomRight = "bottomRight"
     case bottomLeft = "bottomLeft"
+}
+
+enum OverlayCardSize: String, CaseIterable, Identifiable {
+    case small, medium, large
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .small: return "Small"
+        case .medium: return "Medium"
+        case .large: return "Large"
+        }
+    }
+
+    /// The floating NSPanel's bounds. Must stay >= thumbnailSize plus the
+    /// card's own trailing/bottom inset (PreviewCardView) or the thumbnail
+    /// clips against the panel edge.
+    var panelSize: CGSize {
+        switch self {
+        case .small: return CGSize(width: 200, height: 170)
+        case .medium: return CGSize(width: 280, height: 220)
+        case .large: return CGSize(width: 360, height: 270)
+        }
+    }
+
+    /// The visible thumbnail drawn inside the panel.
+    var thumbnailSize: CGSize {
+        switch self {
+        case .small: return CGSize(width: 130, height: 98)
+        case .medium: return CGSize(width: 190, height: 140)
+        case .large: return CGSize(width: 250, height: 180)
+        }
+    }
 }
 
 enum ExportFormat: String, CaseIterable {

--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -80,7 +80,7 @@ final class PreviewOverlay {
         guard let panel, let screen else { return }
 
         let screenFrame = screen.visibleFrame
-        let panelSize = CGSize(width: 200, height: 170)
+        let panelSize = AppPreferences.overlayCardSize.panelSize
 
         let x: CGFloat
         let y: CGFloat
@@ -115,7 +115,11 @@ struct PreviewCardView: View {
     @State private var isHovered = false
     @State private var thumbnail: NSImage?
 
-    private let cardSize = CGSize(width: 130, height: 98)
+    // Read fresh each time a card is shown rather than cached: `dismiss()`
+    // always nils the panel and `show()` always rebuilds it, so a size change
+    // in Settings takes effect on the next capture without any extra wiring.
+    private var cardSize: CGSize { AppPreferences.overlayCardSize.thumbnailSize }
+    private var panelSize: CGSize { AppPreferences.overlayCardSize.panelSize }
 
     private var isVideo: Bool {
         guard let url = overlay.currentURL else { return false }
@@ -177,7 +181,7 @@ struct PreviewCardView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
         .padding(.trailing, 20)
         .padding(.bottom, 24)
-        .frame(width: 200, height: 170)
+        .frame(width: panelSize.width, height: panelSize.height)
         .onChange(of: overlay.currentURL) { _, newURL in
             loadThumbnail(from: newURL)
         }
@@ -200,8 +204,9 @@ struct PreviewCardView: View {
             url: url,
             kind: Self.isVideo(url) ? .recording : .screenshot
         )
+        let sampleSize = max(cardSize.width, cardSize.height) * 2 // retina headroom at the current card size
         Task.detached(priority: .userInitiated) {
-            let image = HistoryStore.decodeThumbnail(source, maxSize: 260)
+            let image = HistoryStore.decodeThumbnail(source, maxSize: sampleSize)
             // Two captures in quick succession race: the older decode can land last
             // and paint the previous capture onto the current card.
             await MainActor.run {

--- a/Sources/Settings/PreferencesView.swift
+++ b/Sources/Settings/PreferencesView.swift
@@ -635,6 +635,7 @@ struct CaptureSettingsTab: View {
     @AppStorage("bs_selfTimerDelay") private var selfTimerRaw: Int = 0
     @AppStorage("bs_overlayPosition") private var overlayPositionRaw: String = OverlayPosition.bottomRight.rawValue
     @AppStorage("bs_overlayDismissDelay") private var overlayDismissDelay: Double = 5.0
+    @AppStorage("bs_overlayCardSize") private var overlayCardSizeRaw: String = OverlayCardSize.small.rawValue
     @AppStorage("bs_openEditorAfterCapture") private var openEditorAfterCapture = false
     @State private var isConfirmingReset = false
 
@@ -649,6 +650,13 @@ struct CaptureSettingsTab: View {
         Binding(
             get: { OverlayPosition(rawValue: overlayPositionRaw) ?? .bottomRight },
             set: { overlayPositionRaw = $0.rawValue }
+        )
+    }
+
+    private var overlayCardSize: Binding<OverlayCardSize> {
+        Binding(
+            get: { OverlayCardSize(rawValue: overlayCardSizeRaw) ?? .small },
+            set: { overlayCardSizeRaw = $0.rawValue }
         )
     }
 
@@ -672,6 +680,13 @@ struct CaptureSettingsTab: View {
                     Text("Bottom Right").tag(OverlayPosition.bottomRight)
                     Text("Bottom Left").tag(OverlayPosition.bottomLeft)
                 }
+
+                Picker("Size", selection: overlayCardSize) {
+                    ForEach(OverlayCardSize.allCases) { size in
+                        Text(size.label).tag(size)
+                    }
+                }
+                .pickerStyle(.segmented)
 
                 LabeledContent("Hide it after") {
                     HStack(spacing: 12) {
@@ -710,6 +725,7 @@ struct CaptureSettingsTab: View {
                 selfTimerRaw = 0
                 overlayPositionRaw = OverlayPosition.bottomRight.rawValue
                 overlayDismissDelay = 5.0
+                overlayCardSizeRaw = OverlayCardSize.small.rawValue
                 openEditorAfterCapture = false
             }
             Button("Cancel", role: .cancel) {}


### PR DESCRIPTION
## What

The floating preview card that pops up after a capture (`PreviewOverlay.swift`) has always been a hardcoded 130x98px thumbnail in a 200x170 panel. This adds a **Small / Medium / Large** picker in **Settings > Capture > Preview Thumbnail**, right next to the existing position/dismiss-delay controls.

- **Small** is the default and is byte-identical to the prior hardcoded size — existing users see zero behavior change unless they opt into a bigger card.
- **Medium**: 280x220 panel, 190x140 thumbnail
- **Large**: 360x270 panel, 250x180 thumbnail

The thumbnail decode's sample resolution (`HistoryStore.decodeThumbnail`'s `maxSize`) now scales with the chosen card size (2x the longest edge, for retina sharpness) instead of a hardcoded 260 — so Large doesn't look soft.

## Why

Requested by a user coming from CleanShot X who found the default preview card too small to make out at a glance.

## How it's implemented

Follows the exact pattern CONTRIBUTING.md documents for adding a preference:
1. `Sources/Models/AppPreferences.swift` — new `OverlayCardSize` enum (mirrors the shape of the adjacent `OverlayPosition`/`AppAppearance` enums) + a `overlayCardSize` UserDefaults-backed computed property (key `bs_overlayCardSize`), same pattern as the existing `overlayPosition`/`overlayDismissDelay` properties right above it.
2. `Sources/Preview/PreviewOverlay.swift` — the two hardcoded `CGSize` constants become reads from `AppPreferences.overlayCardSize`.
3. `Sources/Settings/PreferencesView.swift` — a segmented `Picker` in the existing "Preview Thumbnail" section, wired into the "Restore Defaults" reset dialog.

## Testing

Built and verified with Xcode 26.6 on macOS 26: Debug build succeeds with no errors and no new warnings in the three changed files.

Note for anyone else building a fork — `project.yml` pins `DEVELOPMENT_TEAM` to the maintainer's Developer ID, so a plain `make build` fails on code signing. Overriding it works:

```
xcodebuild -project BetterShot.xcodeproj -scheme BetterShot -configuration Debug \
  -derivedDataPath .build \
  CODE_SIGN_IDENTITY="-" CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM="" build
```

Also worth knowing: `make build` currently exits 0 even when the build fails, because each recipe pipes `xcodebuild` into `tail` and a pipeline returns the last command's status. Details and a two-line fix in the comment below.

**Still not verified by eye.** The compiler is happy and the geometry checks out on paper (padding stays uniform at every size, no overflow against the panel bounds), but I haven't seen the card rendered at Medium and Large. Worth a glance before merging.

## Checklist

- [x] Focused, single-purpose diff (3 files, ~70 lines)
- [x] Matches existing code style and the "no abstractions for their own sake" guidance
- [x] Backward compatible (`.small` default = unchanged behavior)
- [x] Compiles clean in a real Xcode build
- [ ] Visually confirmed at all three sizes (see above)