### PR TITLE
feat: configurable preview-card edge margin, and controls that scale

### DIFF
--- a/Sources/Models/AppPreferences.swift
+++ b/Sources/Models/AppPreferences.swift
@@ -11,6 +11,7 @@ enum AppPreferences {
     private static let overlayPositionKey = "bs_overlayPosition"
     private static let overlayDismissDelayKey = "bs_overlayDismissDelay"
     private static let overlayCardSizeKey = "bs_overlayCardSize"
+    private static let overlayEdgeMarginKey = "bs_overlayEdgeMargin"
     private static let exportFormatKey = "bs_exportFormat"
     private static let exportQualityKey = "bs_exportQuality"
     private static let selfTimerKey = "bs_selfTimerDelay"
@@ -86,6 +87,23 @@ enum AppPreferences {
             return size
         }
         set { UserDefaults.standard.set(newValue.rawValue, forKey: overlayCardSizeKey) }
+    }
+
+    static let overlayEdgeMarginDefault: Double = 20
+    static let overlayEdgeMarginRange: ClosedRange<Double> = 0...48
+
+    /// How far the preview card is held off the screen edges it is pinned to.
+    static var overlayEdgeMargin: Double {
+        get {
+            // Zero is a real choice here (card flush into the corner), so an
+            // unset key has to be told apart from a stored 0 rather than
+            // leaning on `double(forKey:)` returning 0 for both.
+            guard UserDefaults.standard.object(forKey: overlayEdgeMarginKey) != nil else {
+                return overlayEdgeMarginDefault
+            }
+            return UserDefaults.standard.double(forKey: overlayEdgeMarginKey)
+        }
+        set { UserDefaults.standard.set(newValue, forKey: overlayEdgeMarginKey) }
     }
 
     // MARK: - Export
@@ -224,14 +242,33 @@ enum OverlayCardSize: String, CaseIterable, Identifiable {
         }
     }
 
-    /// The floating NSPanel's bounds. Must stay >= thumbnailSize plus the
-    /// card's own trailing/bottom inset (PreviewCardView) or the thumbnail
-    /// clips against the panel edge.
-    var panelSize: CGSize {
+    /// Room the panel needs beyond the thumbnail and its edge inset so the
+    /// card's drop shadow (`radius: 14, y: 6` in PreviewCardView) has
+    /// somewhere to render instead of clipping against the panel bounds.
+    private static let shadowHeadroom: CGFloat = 24
+
+    /// The floating NSPanel's bounds. The card is inset from the panel's
+    /// screen-facing corner by `margin`, so the panel has to hold the
+    /// thumbnail, that inset, and the shadow headroom. The panel is
+    /// transparent and `positionPanel()` pins it flush to the screen edge, so
+    /// these bounds decide only where the shadow may draw, never where the
+    /// card lands on screen.
+    func panelSize(margin: Double) -> CGSize {
+        CGSize(
+            width: thumbnailSize.width + margin + Self.shadowHeadroom,
+            height: thumbnailSize.height + margin + Self.shadowHeadroom
+        )
+    }
+
+    /// The hover controls scale with the card so they do not shrink into
+    /// nothing on a Large one. Deliberately sub-linear: matching the
+    /// thumbnail's own 1.0/1.46/1.92 width ratio makes the Large icons
+    /// cartoonishly big next to the rest of the system UI.
+    var controlScale: CGFloat {
         switch self {
-        case .small: return CGSize(width: 200, height: 170)
-        case .medium: return CGSize(width: 280, height: 220)
-        case .large: return CGSize(width: 360, height: 270)
+        case .small: return 1.0
+        case .medium: return 1.25
+        case .large: return 1.5
         }
     }
 

--- a/Sources/Models/AppPreferences.swift
+++ b/Sources/Models/AppPreferences.swift
@@ -10,6 +10,7 @@ enum AppPreferences {
     private static let playSoundKey = "bs_playSound"
     private static let overlayPositionKey = "bs_overlayPosition"
     private static let overlayDismissDelayKey = "bs_overlayDismissDelay"
+    private static let overlayCardSizeKey = "bs_overlayCardSize"
     private static let exportFormatKey = "bs_exportFormat"
     private static let exportQualityKey = "bs_exportQuality"
     private static let selfTimerKey = "bs_selfTimerDelay"
@@ -76,6 +77,15 @@ enum AppPreferences {
             return val > 0 ? val : 5.0
         }
         set { UserDefaults.standard.set(newValue, forKey: overlayDismissDelayKey) }
+    }
+
+    static var overlayCardSize: OverlayCardSize {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: overlayCardSizeKey),
+                  let size = OverlayCardSize(rawValue: raw) else { return .small }
+            return size
+        }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: overlayCardSizeKey) }
     }
 
     // MARK: - Export
@@ -199,6 +209,40 @@ enum AppAppearance: String, CaseIterable, Identifiable {
 enum OverlayPosition: String, CaseIterable, Codable {
     case bottomRight = "bottomRight"
     case bottomLeft = "bottomLeft"
+}
+
+enum OverlayCardSize: String, CaseIterable, Identifiable {
+    case small, medium, large
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .small: return "Small"
+        case .medium: return "Medium"
+        case .large: return "Large"
+        }
+    }
+
+    /// The floating NSPanel's bounds. Must stay >= thumbnailSize plus the
+    /// card's own trailing/bottom inset (PreviewCardView) or the thumbnail
+    /// clips against the panel edge.
+    var panelSize: CGSize {
+        switch self {
+        case .small: return CGSize(width: 200, height: 170)
+        case .medium: return CGSize(width: 280, height: 220)
+        case .large: return CGSize(width: 360, height: 270)
+        }
+    }
+
+    /// The visible thumbnail drawn inside the panel.
+    var thumbnailSize: CGSize {
+        switch self {
+        case .small: return CGSize(width: 130, height: 98)
+        case .medium: return CGSize(width: 190, height: 140)
+        case .large: return CGSize(width: 250, height: 180)
+        }
+    }
 }
 
 enum ExportFormat: String, CaseIterable {

--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -80,7 +80,7 @@ final class PreviewOverlay {
         guard let panel, let screen else { return }
 
         let screenFrame = screen.visibleFrame
-        let panelSize = CGSize(width: 200, height: 170)
+        let panelSize = AppPreferences.overlayCardSize.panelSize
 
         let x: CGFloat
         let y: CGFloat
@@ -115,7 +115,11 @@ struct PreviewCardView: View {
     @State private var isHovered = false
     @State private var thumbnail: NSImage?
 
-    private let cardSize = CGSize(width: 130, height: 98)
+    // Read fresh each time a card is shown rather than cached: `dismiss()`
+    // always nils the panel and `show()` always rebuilds it, so a size change
+    // in Settings takes effect on the next capture without any extra wiring.
+    private var cardSize: CGSize { AppPreferences.overlayCardSize.thumbnailSize }
+    private var panelSize: CGSize { AppPreferences.overlayCardSize.panelSize }
 
     private var isVideo: Bool {
         guard let url = overlay.currentURL else { return false }
@@ -177,7 +181,7 @@ struct PreviewCardView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
         .padding(.trailing, 20)
         .padding(.bottom, 24)
-        .frame(width: 200, height: 170)
+        .frame(width: panelSize.width, height: panelSize.height)
         .onChange(of: overlay.currentURL) { _, newURL in
             loadThumbnail(from: newURL)
         }
@@ -200,8 +204,9 @@ struct PreviewCardView: View {
             url: url,
             kind: Self.isVideo(url) ? .recording : .screenshot
         )
+        let sampleSize = max(cardSize.width, cardSize.height) * 2 // retina headroom at the current card size
         Task.detached(priority: .userInitiated) {
-            let image = HistoryStore.decodeThumbnail(source, maxSize: 260)
+            let image = HistoryStore.decodeThumbnail(source, maxSize: sampleSize)
             // Two captures in quick succession race: the older decode can land last
             // and paint the previous capture onto the current card.
             await MainActor.run {

--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -80,7 +80,7 @@ final class PreviewOverlay {
         guard let panel, let screen else { return }
 
         let screenFrame = screen.visibleFrame
-        let panelSize = AppPreferences.overlayCardSize.panelSize
+        let panelSize = AppPreferences.overlayCardSize.panelSize(margin: AppPreferences.overlayEdgeMargin)
 
         let x: CGFloat
         let y: CGFloat
@@ -119,7 +119,21 @@ struct PreviewCardView: View {
     // always nils the panel and `show()` always rebuilds it, so a size change
     // in Settings takes effect on the next capture without any extra wiring.
     private var cardSize: CGSize { AppPreferences.overlayCardSize.thumbnailSize }
-    private var panelSize: CGSize { AppPreferences.overlayCardSize.panelSize }
+    private var margin: CGFloat { AppPreferences.overlayEdgeMargin }
+    private var panelSize: CGSize { AppPreferences.overlayCardSize.panelSize(margin: margin) }
+    private var controlScale: CGFloat { AppPreferences.overlayCardSize.controlScale }
+
+    // The card hugs whichever corner the panel is pinned to, so the margin
+    // measures from the same screen edges the user picked. Pinning it to the
+    // trailing edge regardless left the bottom-left card floating a panel's
+    // width in from the screen instead of a margin's width.
+    private var cardAlignment: Alignment {
+        AppPreferences.overlayPosition == .bottomLeft ? .bottomLeading : .bottomTrailing
+    }
+
+    private var marginEdges: Edge.Set {
+        AppPreferences.overlayPosition == .bottomLeft ? [.leading, .bottom] : [.trailing, .bottom]
+    }
 
     private var isVideo: Bool {
         guard let url = overlay.currentURL else { return false }
@@ -143,7 +157,7 @@ struct PreviewCardView: View {
 
                     if isVideo {
                         Image(systemName: "play.circle.fill")
-                            .font(.system(size: 28))
+                            .font(.system(size: 28 * controlScale))
                             .foregroundStyle(.white.opacity(0.9))
                             .shadow(radius: 4)
                     }
@@ -178,9 +192,8 @@ struct PreviewCardView: View {
                 }
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
-        .padding(.trailing, 20)
-        .padding(.bottom, 24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: cardAlignment)
+        .padding(marginEdges, margin)
         .frame(width: panelSize.width, height: panelSize.height)
         .onChange(of: overlay.currentURL) { _, newURL in
             loadThumbnail(from: newURL)
@@ -264,10 +277,10 @@ struct PreviewCardView: View {
                     }
                 }
             }
-            .padding(6)
+            .padding(6 * controlScale)
 
             // Center pill actions
-            HStack(spacing: 6) {
+            HStack(spacing: 6 * controlScale) {
                 pillButton("Copy") {
                     // Copy the capture itself, not the card's thumbnail.
                     if let url = overlay.currentURL {
@@ -291,7 +304,7 @@ struct PreviewCardView: View {
             Image(systemName: systemName)
                 .symbolRenderingMode(.palette)
                 .foregroundStyle(.white, .white.opacity(0.25))
-                .font(.system(size: 16))
+                .font(.system(size: 16 * controlScale))
         }
         .buttonStyle(.plain)
     }
@@ -299,10 +312,10 @@ struct PreviewCardView: View {
     private func pillButton(_ title: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Text(title)
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: 10 * controlScale, weight: .semibold))
                 .foregroundStyle(.primary)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
+                .padding(.horizontal, 8 * controlScale)
+                .padding(.vertical, 3 * controlScale)
                 .background(.white.opacity(0.85), in: Capsule())
         }
         .buttonStyle(.plain)

--- a/Sources/Settings/PreferencesView.swift
+++ b/Sources/Settings/PreferencesView.swift
@@ -635,6 +635,7 @@ struct CaptureSettingsTab: View {
     @AppStorage("bs_selfTimerDelay") private var selfTimerRaw: Int = 0
     @AppStorage("bs_overlayPosition") private var overlayPositionRaw: String = OverlayPosition.bottomRight.rawValue
     @AppStorage("bs_overlayDismissDelay") private var overlayDismissDelay: Double = 5.0
+    @AppStorage("bs_overlayCardSize") private var overlayCardSizeRaw: String = OverlayCardSize.small.rawValue
     @AppStorage("bs_openEditorAfterCapture") private var openEditorAfterCapture = false
     @State private var isConfirmingReset = false
 
@@ -649,6 +650,13 @@ struct CaptureSettingsTab: View {
         Binding(
             get: { OverlayPosition(rawValue: overlayPositionRaw) ?? .bottomRight },
             set: { overlayPositionRaw = $0.rawValue }
+        )
+    }
+
+    private var overlayCardSize: Binding<OverlayCardSize> {
+        Binding(
+            get: { OverlayCardSize(rawValue: overlayCardSizeRaw) ?? .small },
+            set: { overlayCardSizeRaw = $0.rawValue }
         )
     }
 
@@ -672,6 +680,13 @@ struct CaptureSettingsTab: View {
                     Text("Bottom Right").tag(OverlayPosition.bottomRight)
                     Text("Bottom Left").tag(OverlayPosition.bottomLeft)
                 }
+
+                Picker("Size", selection: overlayCardSize) {
+                    ForEach(OverlayCardSize.allCases) { size in
+                        Text(size.label).tag(size)
+                    }
+                }
+                .pickerStyle(.segmented)
 
                 LabeledContent("Hide it after") {
                     HStack(spacing: 12) {
@@ -710,6 +725,7 @@ struct CaptureSettingsTab: View {
                 selfTimerRaw = 0
                 overlayPositionRaw = OverlayPosition.bottomRight.rawValue
                 overlayDismissDelay = 5.0
+                overlayCardSizeRaw = OverlayCardSize.small.rawValue
                 openEditorAfterCapture = false
             }
             Button("Cancel", role: .cancel) {}

--- a/Sources/Settings/PreferencesView.swift
+++ b/Sources/Settings/PreferencesView.swift
@@ -636,6 +636,7 @@ struct CaptureSettingsTab: View {
     @AppStorage("bs_overlayPosition") private var overlayPositionRaw: String = OverlayPosition.bottomRight.rawValue
     @AppStorage("bs_overlayDismissDelay") private var overlayDismissDelay: Double = 5.0
     @AppStorage("bs_overlayCardSize") private var overlayCardSizeRaw: String = OverlayCardSize.small.rawValue
+    @AppStorage("bs_overlayEdgeMargin") private var overlayEdgeMargin: Double = AppPreferences.overlayEdgeMarginDefault
     @AppStorage("bs_openEditorAfterCapture") private var openEditorAfterCapture = false
     @State private var isConfirmingReset = false
 
@@ -688,6 +689,16 @@ struct CaptureSettingsTab: View {
                 }
                 .pickerStyle(.segmented)
 
+                LabeledContent("Keep it off the edge by") {
+                    HStack(spacing: 12) {
+                        Slider(value: $overlayEdgeMargin, in: AppPreferences.overlayEdgeMarginRange, step: 4)
+                        Text("\(Int(overlayEdgeMargin))pt")
+                            .font(.system(.callout, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 44, alignment: .trailing)
+                    }
+                }
+
                 LabeledContent("Hide it after") {
                     HStack(spacing: 12) {
                         Slider(value: $overlayDismissDelay, in: AppPreferences.overlayDismissRange, step: 1)
@@ -726,6 +737,7 @@ struct CaptureSettingsTab: View {
                 overlayPositionRaw = OverlayPosition.bottomRight.rawValue
                 overlayDismissDelay = 5.0
                 overlayCardSizeRaw = OverlayCardSize.small.rawValue
+                overlayEdgeMargin = AppPreferences.overlayEdgeMarginDefault
                 openEditorAfterCapture = false
             }
             Button("Cancel", role: .cancel) {}


### PR DESCRIPTION
> **Stacked on #123.** The first of the two commits here *is* #123, because GitHub won't let a cross-fork PR use an unmerged fork branch as its base. Review only the second commit (`feat: configurable preview-card edge margin...`, 3 files, +81/-19). Merge #123 first and this shrinks to just that commit. Happy to rebase or split it differently if you'd rather.

## What

Three related changes to the post-capture preview card, all in the same "Preview Thumbnail" settings section as #123's size picker.

**1. The card's distance from the screen edge is now a setting.** It was hardcoded at `.padding(.trailing, 20).padding(.bottom, 24)`, which jams the card into the corner with no way to move it. New "Keep it off the edge by" slider, 0-48pt in steps of 4, defaulting to 20 — the old trailing value. The old bottom value of 24 folds into the same setting, so the card is now inset equally on both edges rather than 4pt further up than across.

**2. `OverlayCardSize.panelSize` becomes `panelSize(margin:)`.** It has to, since the panel must grow when the margin does. Rather than hand-tune six more constants, it's now derived: `thumbnail + margin + 24pt of shadow headroom`. That 24 is the room the card's `.shadow(radius: 14, y: 6)` needs to render instead of clipping against the panel bounds.

This replaces six hand-picked numbers with one. The old ones had drifted — headroom was 50x48 at Small but 90x66 at Large, with nothing depending on the difference. Nothing moves on screen as a result: the panel is transparent and `positionPanel()` pins it flush to the screen edge, so its bounds only decide where the shadow may draw. The card's own position is set by the margin alone.

**3. The hover controls scale with the card.** The corner buttons, the Copy/Save pills and the video play badge all used fixed point sizes, so on a Large card they looked proportionally tiny — flagged as a nice-to-have on #123. They now scale via a new `OverlayCardSize.controlScale` (1.0 / 1.25 / 1.5).

Deliberately sub-linear. Matching the thumbnail's own width ratio (1.0 / 1.46 / 1.92) makes the Large icons cartoonish next to the rest of the system UI. I went with a derived value rather than a fourth slider, since "the buttons look small on a big card" is definitionally proportional and nobody wants to tune it independently.

## Bug fix

The margin slider exposed a pre-existing one. `PreviewCardView` always aligned `.bottomTrailing` with trailing padding, regardless of the overlay position setting. With the overlay set to **Bottom Left** the panel is pinned to the left of the screen, so the card ended up floating a panel-width in from the edge instead of one inset — 50pt at Small, 90pt at Large, versus 20pt on the right-hand side.

Alignment and padding edges now follow `overlayPosition`, so the margin measures from the edges the user actually picked. Without this the new setting would be lying at Bottom Left.

## One deliberate style deviation

`overlayEdgeMargin`'s getter checks `object(forKey:) != nil` rather than following the neighbouring `overlayDismissDelay`'s `val > 0 ? val : default` idiom. Zero is a real choice here (card flush into the corner), so a stored 0 has to be distinguishable from an unset key. Commented in place.

## Testing

Built with Xcode 26.6 on macOS 26: Debug build succeeds, no errors, no new warnings in the three changed files.

Same caveat as #123 — not yet verified by eye. The geometry holds arithmetically at every size/margin combination: the two non-pinned edges always get exactly 24pt of shadow room, and the two pinned edges get the margin, so nothing clips until the user deliberately sets the margin below the shadow's reach. Still worth a look before merging.

## Checklist

- [x] Matches existing code style and the "no abstractions for their own sake" guidance
- [x] Backward compatible (default margin 20 and `controlScale` 1.0 at Small = the old look, apart from the intentional 24 to 20 bottom-inset change)
- [x] Compiles clean in a real Xcode build
- [ ] Visually confirmed
