### PR TITLE
ci: build every push and PR, and make a failed build actually fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Release build
+    # macos-26 is the arm64 image and carries Xcode 26, which is what
+    # project.yml targets (arm64-apple-macosx26.0).
+    runs-on: macos-26
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show toolchain
+        run: |
+          xcodebuild -version
+          swift --version
+          sw_vers
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      # `make release` already builds unsigned (CODE_SIGN_IDENTITY=""
+      # CODE_SIGNING_REQUIRED=NO), so it works without the maintainer's
+      # Developer ID. `make build` does not — it inherits DEVELOPMENT_TEAM
+      # from project.yml and fails on any fork.
+      - name: Build
+        run: make release
+
+      - name: Confirm the app was produced
+        run: |
+          app=".build/Build/Products/Release/BetterShot.app"
+          test -d "$app" || { echo "::error::$app was not produced"; exit 1; }
+          echo "Built $app"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 # BetterShot Makefile
+#
+# Recipes pipe xcodebuild into tail/grep. A shell pipeline reports the LAST
+# command's status, so without pipefail a failed build exits 0 and looks green.
+SHELL := /bin/bash
+.SHELLFLAGS := -o pipefail -c
+
 # Usage:
 #   make build        — Debug build
 #   make release      — Release build


### PR DESCRIPTION
Two changes, and the Makefile one is the important half.

## `make build` exits 0 when the build fails

Every build recipe ends in `xcodebuild ... 2>&1 | tail -3`. A shell pipeline reports the **last** command's status, so `tail` succeeding masks `xcodebuild` failing.

Measured on one tree with a deliberate syntax error added to `Sources/Models/AppPreferences.swift`:

```
$ make build ; echo "EXIT=$?"
The following build commands failed:
EXIT=0            <-- 21 compile errors, exit 0

$ # same tree, same command, run under pipefail
EXIT=65           <-- 21 compile errors reported
```

Fix is two lines at the top of the Makefile:

```make
SHELL := /bin/bash
.SHELLFLAGS := -o pipefail -c
```

Recipes that already guard themselves with `|| true` (`clean`, `lint`) are unaffected. This is worth having on its own even without the workflow below, and I'm happy to split it into a separate PR if you'd rather take them one at a time.

## A workflow that builds on every push and PR

`.github/workflows/build.yml`. Builds on pushes to `main`, on every pull request, and on manual dispatch.

Three things worth knowing about how it's set up:

**It runs `make release`, not `make build`.** `release` already passes `CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO`, so it builds without a Developer ID. `make build` inherits `DEVELOPMENT_TEAM` from `project.yml` and fails on any fork with `No signing certificate "Developer ID Application" found`. I left `build` alone rather than changing signing behaviour for your local development — using the target that already works seemed better than editing one that works fine for you.

**`runs-on: macos-26`**, which is the arm64 image and carries Xcode 26. That matches `project.yml`'s `arm64-apple-macosx26.0` deployment target.

**It verifies the `.app` actually landed**, rather than trusting the exit code alone. Belt and braces given the bug above.

## Verified

Green on a real runner before opening this: https://github.com/BradleyAllanDavis/better-shot/actions/runs/33212555927 — 3m16s end to end, including `brew install xcodegen`.

## Why I'm proposing it

I opened #123 and #124 recently and both had to ask you to check out the branch and build it by hand, because there was no other way to know they were sound. That cost lands on you every time anyone contributes. This moves it onto a runner.

Entirely your call, and no hard feelings if a workflow isn't something you want to maintain — the Makefile fix stands on its own either way.