### PR TITLE
Preview card follows mouse across monitors, with a pin-to-display option

### DIFF
--- a/Sources/BetterShot/ActiveDisplayResolver.swift
+++ b/Sources/BetterShot/ActiveDisplayResolver.swift
@@ -37,6 +37,33 @@ enum ActiveDisplayResolver {
         return screenContainingFrontmostWindow() ?? pointerScreen ?? NSScreen.main ?? NSScreen.screens.first
     }
 
+    /// Resolves which display a screenshot capture -- and the preview card
+    /// it produces -- should target. Honors Settings > Capture > Preview
+    /// Thumbnail's "Show it on" choice: whichever display the mouse is on
+    /// (the default), or a display the user pinned. Falls back to the
+    /// mouse-follow behavior if no display was pinned yet, or the pinned
+    /// one got disconnected.
+    static func screenForScreenshotCapture() -> NSScreen? {
+        guard !AppPreferences.overlayFollowsMouse,
+              let pinnedScreen = screen(for: AppPreferences.overlayPinnedDisplayID) else {
+            return activeScreen(preferPointer: true)
+        }
+        return pinnedScreen
+    }
+
+    /// `screencapture -D<n>` indexes displays by their position in
+    /// CGGetActiveDisplayList's ordering (1 = main, 2 = secondary, ...)
+    /// rather than by CGDirectDisplayID, so a target display has to be
+    /// translated through that same list before it can reach the CLI.
+    static func screencaptureDisplayIndex(for displayID: CGDirectDisplayID) -> Int? {
+        var count: UInt32 = 0
+        guard CGGetActiveDisplayList(0, nil, &count) == .success, count > 0 else { return nil }
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetActiveDisplayList(count, &ids, &count) == .success else { return nil }
+        guard let position = ids.firstIndex(of: displayID) else { return nil }
+        return position + 1
+    }
+
     private static func screenContainingMouse() -> NSScreen? {
         screen(containing: NSEvent.mouseLocation)
     }

--- a/Sources/Capture/CaptureOrchestrator.swift
+++ b/Sources/Capture/CaptureOrchestrator.swift
@@ -45,7 +45,7 @@ final class CaptureOrchestrator {
         case .region:
             await captureAndProcess { try await ScreenCapture.shared.captureRegion() }
         case .fullscreen:
-            await captureAndProcess { try await ScreenCapture.shared.captureFullscreen() }
+            await captureAndProcess { try await ScreenCapture.shared.captureFullscreen(on: captureScreen) }
         case .window:
             await captureAndProcess { try await ScreenCapture.shared.captureWindow() }
         case .ocr:

--- a/Sources/Capture/ScreenCapture.swift
+++ b/Sources/Capture/ScreenCapture.swift
@@ -13,7 +13,7 @@ final class ScreenCapture {
 
     // MARK: - Fullscreen 
 
-    func captureFullscreen() async throws -> URL? {
+    func captureFullscreen(on screen: NSScreen? = nil) async throws -> URL? {
         guard !isCapturing else { return nil }
         isCapturing = true
         defer { isCapturing = false }
@@ -21,7 +21,23 @@ final class ScreenCapture {
         try? await Task.sleep(for: .milliseconds(200))
 
         let tempPath = makeTempPath()
-        let success = await runScreencapture(["-x", "-t", "png", tempPath])
+        var args = ["-x", "-t", "png"]
+        // Without -D, screencapture always grabs the main display, regardless
+        // of which one is actually active -- so on a multi-monitor setup a
+        // capture triggered with the mouse on a secondary screen would
+        // silently save the wrong display's content while the preview card
+        // still showed up on the right one. Resolve the same screen the
+        // caller already picked (or fall back to the same follow-mouse /
+        // pinned-display resolution the preview card uses) and target it
+        // explicitly.
+        let targetDisplayID = screen.flatMap(ActiveDisplayResolver.displayID(for:))
+            ?? ActiveDisplayResolver.screenForScreenshotCapture().flatMap(ActiveDisplayResolver.displayID(for:))
+        if let targetDisplayID, let index = ActiveDisplayResolver.screencaptureDisplayIndex(for: targetDisplayID) {
+            args.append(contentsOf: ["-D", String(index)])
+        }
+        args.append(tempPath)
+
+        let success = await runScreencapture(args)
         guard success, FileManager.default.fileExists(atPath: tempPath) else { return nil }
         return URL(fileURLWithPath: tempPath)
     }

--- a/Sources/Capture/ScreenCapture.swift
+++ b/Sources/Capture/ScreenCapture.swift
@@ -34,6 +34,14 @@ final class ScreenCapture {
             ?? ActiveDisplayResolver.screenForScreenshotCapture().flatMap(ActiveDisplayResolver.displayID(for:))
         if let targetDisplayID, let index = ActiveDisplayResolver.screencaptureDisplayIndex(for: targetDisplayID) {
             args.append(contentsOf: ["-D", String(index)])
+        } else {
+            // Falling through here means screencapture grabs the main
+            // display regardless of which one was actually active -- the
+            // exact silent-wrong-display bug this whole fix exists to
+            // prevent. Only expected to happen in a narrow race (e.g. the
+            // target display disconnected between resolution and the sleep
+            // above), but it should be diagnosable if it does.
+            print("BetterShot: could not resolve target display for -D; screencapture will fall back to the main display")
         }
         args.append(tempPath)
 

--- a/Sources/Models/AppPreferences.swift
+++ b/Sources/Models/AppPreferences.swift
@@ -12,6 +12,8 @@ enum AppPreferences {
     private static let overlayDismissDelayKey = "bs_overlayDismissDelay"
     private static let overlayCardSizeKey = "bs_overlayCardSize"
     private static let overlayEdgeMarginKey = "bs_overlayEdgeMargin"
+    private static let overlayFollowsMouseKey = "bs_overlayFollowsMouse"
+    private static let overlayPinnedDisplayIDKey = "bs_overlayPinnedDisplayID"
     private static let exportFormatKey = "bs_exportFormat"
     private static let exportQualityKey = "bs_exportQuality"
     private static let selfTimerKey = "bs_selfTimerDelay"
@@ -107,6 +109,23 @@ enum AppPreferences {
     static var overlayEdgeMargin: Double {
         get { UserDefaults.standard.object(forKey: overlayEdgeMarginKey) as? Double ?? overlayEdgeMarginDefault }
         set { UserDefaults.standard.set(newValue, forKey: overlayEdgeMarginKey) }
+    }
+
+    /// True (the default) shows the preview card on whichever display the
+    /// mouse is on. False pins it to `overlayPinnedDisplayID` instead.
+    static var overlayFollowsMouse: Bool {
+        get { UserDefaults.standard.object(forKey: overlayFollowsMouseKey) as? Bool ?? true }
+        set { UserDefaults.standard.set(newValue, forKey: overlayFollowsMouseKey) }
+    }
+
+    /// The fixed display used when `overlayFollowsMouse` is false. 0 means
+    /// "none chosen yet" -- CGDirectDisplayID 0 is never a real display.
+    static var overlayPinnedDisplayID: CGDirectDisplayID? {
+        get {
+            let raw = UserDefaults.standard.integer(forKey: overlayPinnedDisplayIDKey)
+            return raw == 0 ? nil : CGDirectDisplayID(raw)
+        }
+        set { UserDefaults.standard.set(Int(newValue ?? 0), forKey: overlayPinnedDisplayIDKey) }
     }
 
     // MARK: - Export

--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -15,6 +15,8 @@ final class PreviewOverlay {
     private var panel: NSPanel?
     private var dismissTasks: [URL: Task<Void, Never>] = [:]
     private var targetScreen: NSScreen?
+    private var mouseMovedGlobalMonitor: Any?
+    private var mouseMovedLocalMonitor: Any?
 
     var currentScreen: NSScreen? { targetScreen }
 
@@ -58,6 +60,7 @@ final class PreviewOverlay {
         panel?.orderFront(nil)
 
         scheduleDismiss(for: url)
+        startMouseTrackingIfNeeded()
     }
 
     func remove(_ url: URL) {
@@ -75,6 +78,7 @@ final class PreviewOverlay {
         dismissTasks.values.forEach { $0.cancel() }
         dismissTasks.removeAll()
 
+        stopMouseTracking()
         teardownPanel()
         items.removeAll()
     }
@@ -123,6 +127,54 @@ final class PreviewOverlay {
         panel = nil
     }
 
+    /// Keeps the card on whichever display the mouse is actually on, live,
+    /// for as long as it's showing -- not just at capture time. Only runs
+    /// when Settings > Capture > Preview Thumbnail is set to follow the
+    /// mouse rather than a pinned display; a pinned card should never move.
+    ///
+    /// A screen change always tears the panel down and rebuilds it (the
+    /// same thing show() does) rather than repositioning the existing one
+    /// via setFrame -- moving a live window across a scale-factor boundary
+    /// (Retina main vs. non-Retina externals) is exactly the bug that
+    /// motivated that fix in the first place, and doing it continuously as
+    /// the mouse crosses monitors would hit it far more often than a single
+    /// capture-time reposition ever did.
+    private func startMouseTrackingIfNeeded() {
+        stopMouseTracking()
+        guard AppPreferences.overlayFollowsMouse else { return }
+
+        mouseMovedGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [weak self] _ in
+            Task { @MainActor in self?.handleMouseMoved() }
+        }
+        mouseMovedLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { [weak self] event in
+            Task { @MainActor in self?.handleMouseMoved() }
+            return event
+        }
+    }
+
+    private func stopMouseTracking() {
+        if let monitor = mouseMovedGlobalMonitor {
+            NSEvent.removeMonitor(monitor)
+            mouseMovedGlobalMonitor = nil
+        }
+        if let monitor = mouseMovedLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            mouseMovedLocalMonitor = nil
+        }
+    }
+
+    private func handleMouseMoved() {
+        guard !items.isEmpty, AppPreferences.overlayFollowsMouse else { return }
+        guard let newScreen = ActiveDisplayResolver.activeScreen(preferPointer: true),
+              newScreen != targetScreen else { return }
+
+        targetScreen = newScreen
+        teardownPanel()
+        createPanel()
+        positionPanel()
+        panel?.orderFront(nil)
+    }
+
     // MARK: - Panel Setup
 
     func openAnnotateEditor(for url: URL) {
@@ -159,6 +211,7 @@ final class PreviewOverlay {
         // / pinned-display resolution a fresh capture would use.
         let screen = targetScreen ?? ActiveDisplayResolver.screenForScreenshotCapture()
         guard let panel, let screen else { return }
+        targetScreen = screen // remember what we actually resolved, so live mouse-tracking can diff against it
 
         let screenFrame = screen.visibleFrame
         let panelSize = panelSize

--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -139,10 +139,11 @@ final class PreviewOverlay {
     }
 
     private func positionPanel() {
-        let mouseLocation = NSEvent.mouseLocation
-        let screen = targetScreen
-            ?? NSScreen.screens.first { $0.frame.contains(mouseLocation) }
-            ?? NSScreen.main
+        // An explicit target (the screen a capture actually happened on)
+        // always wins; only a nil target (re-showing a card with no capture
+        // context, e.g. from History) falls through to the same follow-mouse
+        // / pinned-display resolution a fresh capture would use.
+        let screen = targetScreen ?? ActiveDisplayResolver.screenForScreenshotCapture()
         guard let panel, let screen else { return }
 
         let screenFrame = screen.visibleFrame

--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -40,9 +40,19 @@ final class PreviewOverlay {
         }
         targetScreen = screen
 
-        if panel == nil {
-            createPanel()
-        }
+        // Always build a fresh panel rather than repositioning a reused
+        // one. A back-to-back capture (before the previous card's dismiss
+        // timer fires) used to reuse the existing NSPanel and just move it
+        // via setFrame -- moving an existing window between screens with
+        // different backing scale factors (Retina main vs. non-Retina
+        // externals) is a known AppKit trouble spot: it can repaint at the
+        // new position while its cached hit-testing state still points at
+        // the screen it was last shown on, so clicks land somewhere other
+        // than where the buttons are drawn. A panel created fresh on its
+        // final screen, before ever being ordered on-screen, never crosses
+        // that boundary.
+        teardownPanel()
+        createPanel()
 
         positionPanel()
         panel?.orderFront(nil)
@@ -65,8 +75,7 @@ final class PreviewOverlay {
         dismissTasks.values.forEach { $0.cancel() }
         dismissTasks.removeAll()
 
-        panel?.orderOut(nil)
-        panel = nil
+        teardownPanel()
         items.removeAll()
     }
 
@@ -107,6 +116,11 @@ final class PreviewOverlay {
 
     func cancelScheduledDismiss(for url: URL) {
         dismissTasks.removeValue(forKey: url)?.cancel()
+    }
+
+    private func teardownPanel() {
+        panel?.orderOut(nil)
+        panel = nil
     }
 
     // MARK: - Panel Setup

--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -237,11 +237,31 @@ struct PreviewCardView: View {
         Group {
             if let image = thumbnail {
                 ZStack {
+                    // onDrag/onTapGesture live on this base image, not on the
+                    // ZStack as a whole: the hover buttons below are siblings
+                    // drawn on top of it, and a drag-source recognizer
+                    // spanning the whole card (buttons included) beats a
+                    // physical mouse's tiny mouseDown-to-mouseUp jitter to
+                    // the punch, starting a native drag under the Copy/Save
+                    // buttons that snaps back on release — trackpad taps
+                    // don't have enough movement to trigger it, which is why
+                    // this only showed up with a mouse.
                     Image(nsImage: image)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
                         .frame(width: cardSize.width, height: cardSize.height)
                         .clipped()
+                        .onTapGesture {
+                            overlay.openAnnotateEditor(for: url)
+                        }
+                        .onDrag {
+                            DeckStaging.promote(url)
+                            if let provider = NSItemProvider(contentsOf: url) {
+                                provider.suggestedName = url.lastPathComponent
+                                return provider
+                            }
+                            return NSItemProvider(object: image)
+                        }
 
                     if isVideo {
                         Image(systemName: "play.circle.fill")
@@ -266,17 +286,6 @@ struct PreviewCardView: View {
                     withAnimation(.easeInOut(duration: 0.15)) {
                         isHovered = hovering
                     }
-                }
-                .onTapGesture {
-                    overlay.openAnnotateEditor(for: url)
-                }
-                .onDrag {
-                    DeckStaging.promote(url)
-                    if let provider = NSItemProvider(contentsOf: url) {
-                        provider.suggestedName = url.lastPathComponent
-                        return provider
-                    }
-                    return NSItemProvider(object: image)
                 }
             } else {
                 Color.clear.frame(width: cardSize.width, height: cardSize.height)

--- a/Sources/Services/ShortcutService.swift
+++ b/Sources/Services/ShortcutService.swift
@@ -159,12 +159,12 @@ final class ShortcutService {
             if keyCode == shortcut.keyCode && carbonMods == shortcut.modifiers {
                 let pointerLocation = event.location
                 Task { @MainActor in
-                    let mouseScreen = ActiveDisplayResolver.activeScreen(preferPointer: true)
                     if action == .recording {
                         guard !ScreenRecordingManager.shared.isActive else { return }
                         RecordingBarPresenter.shared.togglePicker()
                     } else {
-                        await CaptureOrchestrator.shared.performCapture(action, on: mouseScreen)
+                        let screen = ActiveDisplayResolver.screenForScreenshotCapture()
+                        await CaptureOrchestrator.shared.performCapture(action, on: screen)
                     }
                 }
                 return nil

--- a/Sources/Settings/PreferencesView.swift
+++ b/Sources/Settings/PreferencesView.swift
@@ -637,6 +637,8 @@ struct CaptureSettingsTab: View {
     @AppStorage("bs_overlayDismissDelay") private var overlayDismissDelay: Double = 5.0
     @AppStorage("bs_overlayCardSize") private var overlayCardSizeRaw: String = OverlayCardSize.small.rawValue
     @AppStorage("bs_overlayEdgeMargin") private var overlayEdgeMargin: Double = AppPreferences.overlayEdgeMarginDefault
+    @AppStorage("bs_overlayFollowsMouse") private var overlayFollowsMouse: Bool = true
+    @AppStorage("bs_overlayPinnedDisplayID") private var overlayPinnedDisplayIDRaw: Int = 0
     @AppStorage("bs_openEditorAfterCapture") private var openEditorAfterCapture = false
     @AppStorage("bs_keepInDeckUntilSaved") private var keepInDeckUntilSaved = false
     @State private var isConfirmingReset = false
@@ -659,6 +661,27 @@ struct CaptureSettingsTab: View {
         Binding(
             get: { OverlayCardSize(rawValue: overlayCardSizeRaw) ?? .small },
             set: { overlayCardSizeRaw = $0.rawValue }
+        )
+    }
+
+    /// Every connected display, paired with the ID the picker below tags
+    /// each row with. `NSScreen.screens` can't produce a nil ID in
+    /// practice (every real display carries NSScreenNumber), but the
+    /// compactMap keeps a screen that somehow lacks one out of the list
+    /// rather than crashing the tag lookup.
+    private var connectedScreens: [(id: CGDirectDisplayID, screen: NSScreen)] {
+        NSScreen.screens.compactMap { screen in
+            guard let id = ActiveDisplayResolver.displayID(for: screen) else { return nil }
+            return (id, screen)
+        }
+    }
+
+    private var overlayPinnedDisplayID: Binding<CGDirectDisplayID?> {
+        Binding(
+            get: {
+                overlayPinnedDisplayIDRaw == 0 ? nil : CGDirectDisplayID(overlayPinnedDisplayIDRaw)
+            },
+            set: { overlayPinnedDisplayIDRaw = Int($0 ?? 0) }
         )
     }
 
@@ -709,6 +732,25 @@ struct CaptureSettingsTab: View {
                             .frame(width: 44, alignment: .trailing)
                     }
                 }
+
+                Picker("Show it on", selection: $overlayFollowsMouse) {
+                    Text("Whatever screen my mouse is on").tag(true)
+                    Text("A specific screen").tag(false)
+                }
+                .onChange(of: overlayFollowsMouse) { _, followsMouse in
+                    guard !followsMouse, overlayPinnedDisplayIDRaw == 0,
+                          let mainScreen = NSScreen.main ?? NSScreen.screens.first,
+                          let mainID = ActiveDisplayResolver.displayID(for: mainScreen) else { return }
+                    overlayPinnedDisplayIDRaw = Int(mainID)
+                }
+
+                if !overlayFollowsMouse {
+                    Picker("Screen", selection: overlayPinnedDisplayID) {
+                        ForEach(connectedScreens, id: \.id) { entry in
+                            Text(entry.screen.localizedName).tag(Optional(entry.id))
+                        }
+                    }
+                }
             } header: {
                 Text("Preview Thumbnail")
             } footer: {
@@ -745,6 +787,8 @@ struct CaptureSettingsTab: View {
                 overlayDismissDelay = 5.0
                 overlayCardSizeRaw = OverlayCardSize.small.rawValue
                 overlayEdgeMargin = AppPreferences.overlayEdgeMarginDefault
+                overlayFollowsMouse = true
+                overlayPinnedDisplayIDRaw = 0
                 openEditorAfterCapture = false
                 keepInDeckUntilSaved = false
             }

--- a/Sources/Views/MenuBarContentView.swift
+++ b/Sources/Views/MenuBarContentView.swift
@@ -195,7 +195,7 @@ struct MenuBarContentView: View {
     }
 
     private func dismissAndRun(_ action: ShortcutService.Action) {
-        nonisolated(unsafe) let screen = originScreen
+        nonisolated(unsafe) let screen = ActiveDisplayResolver.screenForScreenshotCapture()
         dismissPopover()
         Task.detached {
             try? await Task.sleep(nanoseconds: 200_000_000)
@@ -212,7 +212,7 @@ struct MenuBarContentView: View {
         } else {
             for record in recentScreenshots.prefix(8) {
                 screenshotItems.append(TrayMenuItem(title: record.filename, icon: "photo") { [record] in
-                    let screen = originScreen
+                    let screen = ActiveDisplayResolver.screenForScreenshotCapture()
                     dismissPopover()
                     let url = HistoryStore.shared.displayURLForRecord(record)
                     PreviewOverlay.shared.show(url: url, on: screen)
@@ -233,7 +233,7 @@ struct MenuBarContentView: View {
         } else {
             for record in recentRecordings.prefix(8) {
                 recordingItems.append(TrayMenuItem(title: record.filename, icon: "video") { [record] in
-                    let screen = originScreen
+                    let screen = ActiveDisplayResolver.screenForScreenshotCapture()
                     dismissPopover()
                     let url = HistoryStore.shared.displayURLForRecord(record)
                     PreviewOverlay.shared.show(url: url, on: screen)


### PR DESCRIPTION
Adds a Settings > Capture > Preview Thumbnail toggle: the preview card either follows whichever display the mouse is on (the existing default, now centralized in one resolver) or pins to a specific display the user picks.

Along the way, found and fixed a real bug this surfaced: `captureFullscreen()` never used the resolved target screen at all — plain `screencapture -x -t png` always grabs the main display regardless of which one is active. On a multi-monitor setup, triggering a fullscreen capture with the mouse on a secondary display silently saved the wrong display's content while the preview card still showed up on the right one. Fixed by threading the resolved screen through to a `-D` argument, translated from `CGDirectDisplayID` to `screencapture`'s ordinal via `CGGetActiveDisplayList`.

**Verified end-to-end** on a real 4-monitor Mac via a temporarily-instrumented build: correct `CGDirectDisplayID` resolved per display, correct `screencapture` ordinal, correct single-display output dimensions (cross-checked against the app's own beautifier padding math and independent manual `screencapture -D` runs), and pinned mode correctly overrides mouse position for both the capture and the preview.

Two more real bugs found and fixed using this in daily driving, both pre-existing and unrelated to the toggle itself:

- **`.onDrag`/`.onTapGesture` were scoped to the whole preview card**, which also contains the hover buttons (Copy, Save, etc.) drawn on top of it. A physical mouse's few pixels of jitter between mouseDown and mouseUp was enough to start a native drag session under the buttons before their own tap gesture won the gesture arena, which then snapped back on release with no drop target — read as the cursor jumping around near Copy/Save. Fixed by moving both modifiers onto the base image, a sibling of the button overlay rather than its ancestor.
- **The preview `NSPanel` was created once and reused across captures**, only repositioned via `setFrame()`. On a mixed-DPI desktop (Retina main + non-Retina externals), moving an existing window across a scale-factor boundary is a known AppKit trouble spot — it can repaint at the new position while its cached hit-testing state still points at the old screen, so clicks land somewhere other than where the buttons are drawn. Fixed by always tearing the panel down and building a fresh one on its final screen, never reusing.

Also added the live-follow behavior this toggle was originally meant to have: while the card is visible and set to follow the mouse (not pinned), it now keeps moving to whichever display the mouse is actually on, not just the display at capture time — a global+local `NSEvent` mouse-moved monitor tears the panel down and rebuilds it on a screen change, deliberately not a live `setFrame` reposition (the same AppKit hazard as the panel-reuse fix above).

Addressed @tembo's review comment: the `-D` resolution's `else` path silently fell through to grabbing the main display — exactly the bug the fix above exists to prevent. Added a diagnostic log for the narrow race where it can still happen (target display disconnects between resolution and the capture delay).

- [ ] Confirmed by eye — the Settings picker (follow-mouse ↔ pinned display, screen list, Restore Defaults) wasn't click-tested in the running app; everything else was.