### PR TITLE
fix: stop showing the grab cursor while a drawing tool is armed

### DIFF
--- a/Sources/BetterShot/AnnotationCanvas.swift
+++ b/Sources/BetterShot/AnnotationCanvas.swift
@@ -664,10 +664,16 @@ struct AnnotationCanvas: View {
 
         if hasActiveInteraction {
             setCursor(model.isTransformingExistingAnnotation ? .closedHand : .placement)
-        } else if model.hoveredAnnotation(at: location, imageFrame: imageFrame, boundaryFrame: boundaryFrame) != nil {
-            setCursor(.openHand)
         } else if model.selectedTool == .select {
-            setCursor(.arrow)
+            // The grab cursor is a promise that a press picks the shape up, which only
+            // Select keeps. A drawing tool draws over whatever is under the pointer, so
+            // it stays on the crosshair however many shapes are already there.
+            let hovering = model.hoveredAnnotation(
+                at: location,
+                imageFrame: imageFrame,
+                boundaryFrame: boundaryFrame
+            ) != nil
+            setCursor(hovering ? .openHand : .arrow)
         } else {
             setCursor(.placement)
         }

--- a/Sources/BetterShot/AnnotationCanvas.swift
+++ b/Sources/BetterShot/AnnotationCanvas.swift
@@ -11,6 +11,7 @@ private enum AnnotationCanvasCursor: Equatable {
     case placement
     case openHand
     case closedHand
+    case text
 
     var nsCursor: NSCursor {
         switch self {
@@ -22,6 +23,8 @@ private enum AnnotationCanvasCursor: Equatable {
             .openHand
         case .closedHand:
             .closedHand
+        case .text:
+            .iBeam
         }
     }
 }
@@ -674,6 +677,14 @@ struct AnnotationCanvas: View {
                 boundaryFrame: boundaryFrame
             ) != nil
             setCursor(hovering ? .openHand : .arrow)
+        } else if model.selectedTool == .text,
+                  model.hoveredAnnotation(
+                      at: location,
+                      imageFrame: imageFrame,
+                      boundaryFrame: boundaryFrame
+                  )?.isText == true {
+            // Text is the one tool that edits what it lands on instead of adding to it.
+            setCursor(.text)
         } else {
             setCursor(.placement)
         }


### PR DESCRIPTION
Closes #129.

### Problem

Hovering a shape you just drew shows the open-hand "grab" cursor, but pressing draws another shape instead of picking the existing one up. #129 hits it with arrows, where the selection handles are visible at the same time, so everything on screen says *grab me* and the click does the opposite.

### Cause

`updateCursor` tested the hover before it tested the tool (`AnnotationCanvas.swift:667`):

```swift
} else if model.hoveredAnnotation(at: location, ...) != nil {
    setCursor(.openHand)
} else if model.selectedTool == .select {
    setCursor(.arrow)
```

So the grab cursor won over every drawing tool. `pointerDown` never agreed with it: only `.select` routes into `beginSelectInteraction`, every other tool goes straight to creating a shape (`AnnoEditorInteraction.swift:16-32`).

The mismatch is older than the report, but it was hard to reach before 0.4.1. Until #108 a tool fell back to Select the moment a shape was committed, so by the time the pointer came to rest on what you had just drawn the editor was usually in Select and the cursor was telling the truth. Now that the tool stays armed, resting on your own work is the normal case.

### Change

The grab cursor is offered only in Select. A drawing tool keeps the crosshair over an existing shape, which is what the press will actually do.

Hit testing moves inside the Select branch as a side effect, so `hoveredAnnotation` stops running on every mouse-moved event while drawing.

Text needed the opposite treatment, which the review caught. It is the one tool that acts on what it lands on: `pointerDown` sends a click on existing text into `startEditingText`, not `createText`. So the crosshair would have been misleading there in the other direction. Hovering existing text with Text armed now shows the I-beam, via a new `.text` case on `AnnotationCanvasCursor`.

I deliberately did not make a drawing tool grab the shape under the pointer instead. That would make it impossible to draw a shape overlapping an existing one — exactly what redaction over a busy screenshot needs — and it is not what Figma, Sketch or Preview do either.

### Verification

No Xcode on this machine (Command Line Tools only), so no `make build`. Type-checked all of `Sources/` with the project's own Swift settings from `project.yml` — `-swift-version 5 -default-isolation MainActor`, the four `SWIFT_APPROACHABLE_CONCURRENCY` features, `MemberImportVisibility`, `-target arm64-apple-macosx26.0` — against a stub of the one SPM dependency: 0 errors, and `main`'s existing 127 warnings are byte-identical with and without the patch.

Manual pass still needed on a machine with Xcode:

- Draw an arrow, hover it with Arrow still armed: crosshair, and a press starts a second arrow.
- Switch to Select, hover the same arrow: open hand, and a press grabs it. Dragging it shows the closed hand.
- Same for rectangle and blur.
- With Text armed, hover empty canvas (crosshair, a press starts a new box) and then existing text (I-beam, a press edits it).
- Hover a selection handle in Select and confirm the resize cursors still win over the grab cursor.
- Crop mode still shows the plain arrow throughout.
