### PR TITLE
feat: add a setting to capture a region on mouse release

### DIFF
--- a/Sources/Capture/RegionSelectionOverlay.swift
+++ b/Sources/Capture/RegionSelectionOverlay.swift
@@ -29,6 +29,8 @@ final class RegionSelectionOverlay {
 
     private func showOverlays() {
         let crosshair = CrosshairCursor.shared.makeCursor()
+        // Read once, so the flow cannot change under a selection already in progress.
+        let capturesOnRelease = AppPreferences.captureRegionOnRelease
 
         for screen in NSScreen.screens {
             let window = OverlayWindow(
@@ -47,7 +49,12 @@ final class RegionSelectionOverlay {
 
             let ghost = AppPreferences.lastRegionRect
                 .flatMap { screen.frame.contains($0) ? RegionGeometry.localRect(global: $0, screenFrame: screen.frame) : nil }
-            let overlayView = SelectionView(screen: screen, cursor: crosshair, ghost: ghost) { [weak self] rect in
+            let overlayView = SelectionView(
+                screen: screen,
+                cursor: crosshair,
+                ghost: ghost,
+                capturesOnRelease: capturesOnRelease
+            ) { [weak self] rect in
                 self?.finishSelection(rect: rect, screen: screen)
             } onCancel: { [weak self] in
                 self?.finish(.cancelled)
@@ -183,6 +190,7 @@ private final class SelectionView: NSView {
     private let screen: NSScreen
     private let crosshairCursor: NSCursor
     private let ghost: CGRect?
+    private let capturesOnRelease: Bool
     private let onSelect: (CGRect) -> Void
     private let onCancel: () -> Void
     private let onWindow: () -> Void
@@ -191,6 +199,7 @@ private final class SelectionView: NSView {
         screen: NSScreen,
         cursor: NSCursor,
         ghost: CGRect?,
+        capturesOnRelease: Bool,
         onSelect: @escaping (CGRect) -> Void,
         onCancel: @escaping () -> Void,
         onWindow: @escaping () -> Void
@@ -198,6 +207,7 @@ private final class SelectionView: NSView {
         self.screen = screen
         self.crosshairCursor = cursor
         self.ghost = ghost
+        self.capturesOnRelease = capturesOnRelease
         self.onSelect = onSelect
         self.onCancel = onCancel
         self.onWindow = onWindow
@@ -439,6 +449,10 @@ private final class SelectionView: NSView {
         let rect = rectFromPoints(start, end)
 
         if rect.width > 3, rect.height > 3 {
+            if capturesOnRelease {
+                onSelect(rect)
+                return
+            }
             onBeginSelection()
             selection = rect
             updateCursor(at: end)

--- a/Sources/Models/AppPreferences.swift
+++ b/Sources/Models/AppPreferences.swift
@@ -26,6 +26,7 @@ enum AppPreferences {
     private static let recordingCameraDeviceIDKey = "bs_recordingCameraDeviceID"
     private static let recordingMicrophoneDeviceIDKey = "bs_recordingMicrophoneDeviceID"
     private static let lastRegionRectKey = "bs_lastRegionRect"
+    private static let captureRegionOnReleaseKey = "bs_captureRegionOnRelease"
 
     // MARK: - Appearance
     static var appearance: AppAppearance {
@@ -181,6 +182,14 @@ enum AppPreferences {
     static var keepInDeckUntilSaved: Bool {
         get { UserDefaults.standard.bool(forKey: keepInDeckUntilSavedKey) }
         set { UserDefaults.standard.set(newValue, forKey: keepInDeckUntilSavedKey) }
+    }
+
+    /// Takes the shot the moment the mouse comes up, skipping the adjustable
+    /// rectangle. The pre-0.4.3 flow, kept for people who draw the region in one
+    /// stroke and never nudge it.
+    static var captureRegionOnRelease: Bool {
+        get { UserDefaults.standard.bool(forKey: captureRegionOnReleaseKey) }
+        set { UserDefaults.standard.set(newValue, forKey: captureRegionOnReleaseKey) }
     }
 
     // MARK: - History

--- a/Sources/Settings/PreferencesView.swift
+++ b/Sources/Settings/PreferencesView.swift
@@ -639,6 +639,7 @@ struct CaptureSettingsTab: View {
     @AppStorage("bs_overlayEdgeMargin") private var overlayEdgeMargin: Double = AppPreferences.overlayEdgeMarginDefault
     @AppStorage("bs_openEditorAfterCapture") private var openEditorAfterCapture = false
     @AppStorage("bs_keepInDeckUntilSaved") private var keepInDeckUntilSaved = false
+    @AppStorage("bs_captureRegionOnRelease") private var captureRegionOnRelease = false
     @State private var isConfirmingReset = false
 
     private var selfTimerDelay: Binding<SelfTimerDelay> {
@@ -675,6 +676,17 @@ struct CaptureSettingsTab: View {
                 Text("Timer")
             } footer: {
                 Text("Buys you a moment to open a menu or hover something before the shot is taken.")
+            }
+
+            Section {
+                Toggle(isOn: $captureRegionOnRelease) {
+                    Text("Capture as soon as I let go")
+                    Text("Off, the rectangle stays up with handles so you can nudge it, and Return or a double-click takes the shot.")
+                }
+            } header: {
+                Text("Region")
+            } footer: {
+                Text("Space still switches to window selection, and Escape still cancels. Your last region stays a click away either way.")
             }
 
             Section {
@@ -747,6 +759,7 @@ struct CaptureSettingsTab: View {
                 overlayEdgeMargin = AppPreferences.overlayEdgeMarginDefault
                 openEditorAfterCapture = false
                 keepInDeckUntilSaved = false
+                captureRegionOnRelease = false
             }
             Button("Cancel", role: .cancel) {}
         }


### PR DESCRIPTION
Closes #131.

### Problem

0.4.3's adjustable rectangle (#49) made region capture two steps: `mouseUp` stores the rectangle and waits for `Return` or a double-click. For anyone who draws the region in one stroke and never nudges it, that is a keystroke added to the most-used action in the app, against the muscle memory of every earlier version and of `⌘⇧4` itself. There was no way to opt out.

### Change

Settings > Capture gains a Region section with one toggle, **off by default**, so 0.4.3's flow is still what you get without asking for anything:

> **Capture as soon as I let go**
> Off, the rectangle stays up with handles so you can nudge it, and Return or a double-click takes the shot.

On, `mouseUp` calls `onSelect` with the rectangle just drawn and returns before the adjustable state is ever entered — the handles and the `drag to adjust · ↩ to capture` label simply never appear, rather than being drawn and then bypassed.

### Design notes

- **Read once, at overlay time.** `showOverlays()` reads the preference into a local and hands it to every `SelectionView`. Toggling the setting mid-selection therefore cannot change the gesture under a selection already in progress, and the multi-display case gets one consistent answer instead of each screen's view reading `UserDefaults` on its own.
- **Everything else is untouched.** `Space` still switches to window selection, `Escape` still cancels, and the last-region ghost still captures on a single click or `A` — those paths already called `onSelect` directly and were never part of the two-step flow. The 3pt minimum that distinguishes a drag from a click is unchanged, so a stray click still falls through to the ghost or cancel branch exactly as before.
- **`onBeginSelection()` is skipped in the new path.** Its only job is clearing a stored selection on the other screens' overlays, and in this mode no screen ever stores one.
- **OCR follows along**, since `captureAndOCR` goes through `captureRegion()`. That seems right: whichever gesture you have chosen for picking a region, picking one to read text out of should behave the same. The color picker is unaffected — it runs its own `ColorPickerOverlay` and never touches this code.
- The preference sits in `AppPreferences` beside `lastRegionRect`, and is reset by Capture's Restore Defaults along with the rest of the tab.

I kept this to a boolean rather than a three-way picker. There are only two behaviours, and the toggle's subtitle is where the other one gets explained, following the pattern the rest of the tab uses since 0.4.3.

### Verification

No Xcode on this machine (Command Line Tools only), so no `make build`. Type-checked all of `Sources/` with the project's own Swift settings from `project.yml` — `-swift-version 5 -default-isolation MainActor`, the four `SWIFT_APPROACHABLE_CONCURRENCY` features, `MemberImportVisibility`, `-target arm64-apple-macosx26.0` — against a stub of the one SPM dependency: 0 errors, and `main`'s existing 127 warnings are byte-identical with and without the patch.

Manual pass still needed on a machine with Xcode:

**Toggle off (default), nothing should have changed:**
- Draw a region, let go, adjust a handle, press `Return` — shot matches the adjusted rectangle.
- Double-click inside the rectangle captures; `Escape` cancels; `Space` switches to window selection.

**Toggle on:**
- Draw a region and let go — the shot is taken immediately, with no handles and no label flash.
- The captured area matches the rectangle drawn, including on a secondary and a negative-origin display.
- `Escape` before releasing still cancels; `Space` still switches to window selection.
- The last-region ghost still captures on a single click inside it, and on `A`.
- A stray click with no drag still cancels rather than capturing a 1px shot.
- OCR (region) takes the text region immediately too.

**Both:**
- Toggle the setting while the overlay is up on the other display and confirm the in-progress selection keeps the gesture it started with.
- Capture > Restore Defaults puts it back to off.
