### PR TITLE
feat: add a toggle for copying direct file links

### DIFF
--- a/Sources/Settings/SharingSettingsTab.swift
+++ b/Sources/Settings/SharingSettingsTab.swift
@@ -9,6 +9,7 @@ struct SharingSettingsTab: View {
     @State private var secretAccessKey = ""
     @State private var bucket = ""
     @State private var publicBaseURL = ""
+    @State private var useDirectLinks = false
 
     @State private var isTesting = false
     @State private var testStatus: TestStatus = .idle
@@ -32,7 +33,7 @@ struct SharingSettingsTab: View {
                 secureField("Access Key ID", text: $accessKeyID, prompt: "From your API token")
                 secureField("Secret Access Key", text: $secretAccessKey, prompt: "Shown once when the token is created")
                 credentialField("Bucket", text: $bucket, prompt: "my-bucket")
-                credentialField("Public URL", text: $publicBaseURL, prompt: "https://share.example.com")
+                credentialField("Public Bucket URL", text: $publicBaseURL, prompt: "https://share.example.com")
             } header: {
                 HStack {
                     Text("Cloudflare R2")
@@ -42,7 +43,7 @@ struct SharingSettingsTab: View {
                         .textCase(.none)
                 }
             } footer: {
-                Text("In the dashboard, create a bucket, turn on public access or bind a custom domain to it, then create an API token under R2 \u{203A} Manage API Tokens with Object Read & Write. Keys are saved to your login Keychain and never leave this Mac.")
+                Text("In the dashboard, create a bucket, turn on public access or bind a custom domain to it, then create an API token under R2 \u{203A} Manage API Tokens with Object Read & Write. Public Bucket URL is that public address - your files are served from there, and it is the only place they are stored. Keys are saved to your login Keychain and never leave this Mac.")
             }
 
             Section {
@@ -88,8 +89,15 @@ struct SharingSettingsTab: View {
                 }
                 .disabled(!store.isConfigured)
                 .onChange(of: enabled) { _, isOn in store.enabled = isOn }
+
+                Toggle(isOn: $useDirectLinks) {
+                    Text("Copy direct file links")
+                    Text("Link straight to the file in your bucket instead of a viewer page on bettershot.site.")
+                }
+                .disabled(!store.isConfigured)
+                .onChange(of: useDirectLinks) { _, isOn in store.useDirectLinks = isOn }
             } footer: {
-                Text("A successful test turns uploads on for you. With uploads off, everything stays on this Mac.")
+                Text("A successful test turns uploads on for you. With uploads off, everything stays on this Mac. A viewer link shows the title, a poster and a download button, and hides the filename behind a random ID; a direct link is the raw file, filename and all.")
             }
         }
         .formStyle(.grouped)
@@ -184,6 +192,7 @@ struct SharingSettingsTab: View {
         secretAccessKey = store.secretAccessKey
         bucket = store.bucket
         publicBaseURL = store.publicBaseURL
+        useDirectLinks = store.useDirectLinks
     }
 
     private func save() {

--- a/Sources/Settings/SharingSettingsTab.swift
+++ b/Sources/Settings/SharingSettingsTab.swift
@@ -98,8 +98,7 @@ struct SharingSettingsTab: View {
                     Text("Copy direct file links")
                     Text("Link straight to the file in your bucket instead of a viewer page on bettershot.site.")
                 }
-                // Deliberately not gated on isConfigured, which an empty Public Bucket URL
-                // already fails: a dead switch cannot explain why it will not turn on.
+                // Not gated on isConfigured, which an empty URL already fails: a dead switch cannot explain itself.
                 .onChange(of: useDirectLinks) { _, isOn in directLinksToggled(isOn) }
 
                 if let directLinksProblem {
@@ -192,9 +191,7 @@ struct SharingSettingsTab: View {
                     .focused($publicURLFocused)
                     .onChange(of: publicBaseURL) { _, _ in publicURLChanged() }
                     .onChange(of: publicURLFocused) { _, focused in
-                        // Judge the field only once the user moves on. Flagging while they
-                        // type would call "https:/" a mistake mid-keystroke. An empty field
-                        // is not a mistake yet either - the toggle below is what insists on it.
+                        // Only once the user moves on, or "https:/" is an error mid-keystroke.
                         guard !focused else { return }
                         showPublicURLProblem = publicURLProblem != nil && publicURLProblem != .empty
                     }
@@ -210,8 +207,6 @@ struct SharingSettingsTab: View {
         }
     }
 
-    /// Says what is blocked, not just what is wrong. The field's own message reads
-    /// oddly under a switch, where the question is why the switch will not stay on.
     private static func blockedMessage(for problem: ShareBundle.PublicBaseURLProblem) -> String {
         problem == .empty
             ? "Add the Public Bucket URL above first - a direct link points straight at it."
@@ -221,13 +216,8 @@ struct SharingSettingsTab: View {
     private func publicURLChanged() {
         save()
 
-        // Direct links are built from this address and nothing else. Leaving the switch
-        // on while it is unusable would promise a link the uploader cannot build, so it
-        // goes off on its own. The switch moving is the feedback; the message below is
-        // reserved for a tap, where the user has actually asked for something.
         if useDirectLinks, publicURLProblem != nil {
-            // Store first: the assignment below echoes into directLinksToggled, which
-            // compares against the store to tell a real tap from an echo.
+            // Store first, so the echo below sees the new value.
             store.useDirectLinks = false
             useDirectLinks = false
             return
@@ -239,8 +229,7 @@ struct SharingSettingsTab: View {
     }
 
     private func directLinksToggled(_ isOn: Bool) {
-        // loadFromStore and the revert below both echo back through onChange.
-        // Neither is the user pressing the switch.
+        // loadFromStore and the revert below echo back through here; neither is a tap.
         guard isOn != store.useDirectLinks else { return }
 
         guard isOn else {
@@ -249,8 +238,6 @@ struct SharingSettingsTab: View {
             return
         }
 
-        // A direct link is built straight from this field, so an unusable address has to
-        // be caught here rather than at share time, when the capture is already gone.
         if let publicURLProblem {
             directLinksProblem = Self.blockedMessage(for: publicURLProblem)
             showPublicURLProblem = publicURLProblem != .empty
@@ -289,10 +276,7 @@ struct SharingSettingsTab: View {
         publicBaseURL = store.publicBaseURL
         useDirectLinks = store.useDirectLinks
 
-        // A stored "on" can outlive the address it depends on, because the URL may have
-        // been cleared in an earlier session. Nothing changes on appear, so no handler
-        // would fire: reconcile here or the switch shows on against an empty field.
-        // Silently - an error on a pane the user just opened is scolding, not helping.
+        // Nothing changes on appear, so no handler would fire: reconcile the stored value here.
         if useDirectLinks, publicURLProblem != nil {
             store.useDirectLinks = false
             useDirectLinks = false

--- a/Sources/Settings/SharingSettingsTab.swift
+++ b/Sources/Settings/SharingSettingsTab.swift
@@ -11,6 +11,10 @@ struct SharingSettingsTab: View {
     @State private var publicBaseURL = ""
     @State private var useDirectLinks = false
 
+    @FocusState private var publicURLFocused: Bool
+    @State private var showPublicURLProblem = false
+    @State private var directLinksProblem: String?
+
     @State private var isTesting = false
     @State private var testStatus: TestStatus = .idle
 
@@ -33,7 +37,7 @@ struct SharingSettingsTab: View {
                 secureField("Access Key ID", text: $accessKeyID, prompt: "From your API token")
                 secureField("Secret Access Key", text: $secretAccessKey, prompt: "Shown once when the token is created")
                 credentialField("Bucket", text: $bucket, prompt: "my-bucket")
-                credentialField("Public Bucket URL", text: $publicBaseURL, prompt: "https://share.example.com")
+                publicURLField
             } header: {
                 HStack {
                     Text("Cloudflare R2")
@@ -94,8 +98,16 @@ struct SharingSettingsTab: View {
                     Text("Copy direct file links")
                     Text("Link straight to the file in your bucket instead of a viewer page on bettershot.site.")
                 }
-                .disabled(!store.isConfigured)
-                .onChange(of: useDirectLinks) { _, isOn in store.useDirectLinks = isOn }
+                // Deliberately not gated on isConfigured, which an empty Public Bucket URL
+                // already fails: a dead switch cannot explain why it will not turn on.
+                .onChange(of: useDirectLinks) { _, isOn in directLinksToggled(isOn) }
+
+                if let directLinksProblem {
+                    Label(directLinksProblem, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.red)
+                        .font(.callout)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             } footer: {
                 Text("A successful test turns uploads on for you. With uploads off, everything stays on this Mac. A viewer link shows the title, a poster and a download button, and hides the filename behind a random ID; a direct link is the raw file, filename and all.")
             }
@@ -167,6 +179,89 @@ struct SharingSettingsTab: View {
         .padding(.vertical, 2)
     }
 
+    private var publicURLProblem: ShareBundle.PublicBaseURLProblem? {
+        ShareBundle.validatePublicBaseURL(publicBaseURL)
+    }
+
+    private var publicURLField: some View {
+        LabeledContent("Public Bucket URL") {
+            VStack(alignment: .leading, spacing: 4) {
+                TextField("Public Bucket URL", text: $publicBaseURL, prompt: Text("https://share.example.com"))
+                    .labelsHidden()
+                    .textFieldStyle(.roundedBorder)
+                    .focused($publicURLFocused)
+                    .onChange(of: publicBaseURL) { _, _ in publicURLChanged() }
+                    .onChange(of: publicURLFocused) { _, focused in
+                        // Judge the field only once the user moves on. Flagging while they
+                        // type would call "https:/" a mistake mid-keystroke. An empty field
+                        // is not a mistake yet either - the toggle below is what insists on it.
+                        guard !focused else { return }
+                        showPublicURLProblem = publicURLProblem != nil && publicURLProblem != .empty
+                    }
+
+                if showPublicURLProblem, let publicURLProblem {
+                    Label(publicURLProblem.message, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.red)
+                        .font(.callout)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    /// Says what is blocked, not just what is wrong. The field's own message reads
+    /// oddly under a switch, where the question is why the switch will not stay on.
+    private static func blockedMessage(for problem: ShareBundle.PublicBaseURLProblem) -> String {
+        problem == .empty
+            ? "Add the Public Bucket URL above first - a direct link points straight at it."
+            : problem.message
+    }
+
+    private func publicURLChanged() {
+        save()
+
+        // Direct links are built from this address and nothing else. Leaving the switch
+        // on while it is unusable would promise a link the uploader cannot build, so it
+        // goes off on its own. The switch moving is the feedback; the message below is
+        // reserved for a tap, where the user has actually asked for something.
+        if useDirectLinks, publicURLProblem != nil {
+            // Store first: the assignment below echoes into directLinksToggled, which
+            // compares against the store to tell a real tap from an echo.
+            store.useDirectLinks = false
+            useDirectLinks = false
+            return
+        }
+
+        guard publicURLProblem == nil else { return }
+        showPublicURLProblem = false
+        directLinksProblem = nil
+    }
+
+    private func directLinksToggled(_ isOn: Bool) {
+        // loadFromStore and the revert below both echo back through onChange.
+        // Neither is the user pressing the switch.
+        guard isOn != store.useDirectLinks else { return }
+
+        guard isOn else {
+            store.useDirectLinks = false
+            directLinksProblem = nil
+            return
+        }
+
+        // A direct link is built straight from this field, so an unusable address has to
+        // be caught here rather than at share time, when the capture is already gone.
+        if let publicURLProblem {
+            directLinksProblem = Self.blockedMessage(for: publicURLProblem)
+            showPublicURLProblem = publicURLProblem != .empty
+            useDirectLinks = false
+            return
+        }
+
+        directLinksProblem = nil
+        store.useDirectLinks = true
+    }
+
     private func credentialField(_ label: String, text: Binding<String>, prompt: String) -> some View {
         LabeledContent(label) {
             TextField(label, text: text, prompt: Text(prompt))
@@ -193,6 +288,15 @@ struct SharingSettingsTab: View {
         bucket = store.bucket
         publicBaseURL = store.publicBaseURL
         useDirectLinks = store.useDirectLinks
+
+        // A stored "on" can outlive the address it depends on, because the URL may have
+        // been cleared in an earlier session. Nothing changes on appear, so no handler
+        // would fire: reconcile here or the switch shows on against an empty field.
+        // Silently - an error on a pane the user just opened is scolding, not helping.
+        if useDirectLinks, publicURLProblem != nil {
+            store.useDirectLinks = false
+            useDirectLinks = false
+        }
     }
 
     private func save() {

--- a/Sources/Sharing/R2CredentialStore.swift
+++ b/Sources/Sharing/R2CredentialStore.swift
@@ -6,6 +6,7 @@ struct R2Credentials: Sendable {
     let accountID: String
     let bucket: String
     let publicBaseURL: String
+    let useDirectLinks: Bool
     let accessKeyID: String
     let secretAccessKey: String
     let enabled: Bool
@@ -28,6 +29,7 @@ final class R2CredentialStore {
         static let accountID = "bs_r2_accountID"
         static let bucket = "bs_r2_bucket"
         static let publicBaseURL = "bs_r2_publicBaseURL"
+        static let useDirectLinks = "bs_r2_useDirectLinks"
         static let enabled = "bs_r2_enabled"
         static let accessKeyID = "accessKeyID"
         static let secretAccessKey = "secretAccessKey"
@@ -36,6 +38,7 @@ final class R2CredentialStore {
     private(set) var _accountID: String = ""
     private(set) var _bucket: String = ""
     private(set) var _publicBaseURL: String = ""
+    private(set) var _useDirectLinks: Bool = false
     private(set) var _enabled: Bool = false
     private(set) var _accessKeyID: String = ""
     private(set) var _secretAccessKey: String = ""
@@ -74,6 +77,15 @@ final class R2CredentialStore {
         }
     }
 
+    /// Off by default: an existing install keeps handing out viewer links until someone opts out.
+    var useDirectLinks: Bool {
+        get { _useDirectLinks }
+        set {
+            _useDirectLinks = newValue
+            defaults.set(newValue, forKey: Keys.useDirectLinks)
+        }
+    }
+
     var enabled: Bool {
         get { _enabled }
         set {
@@ -107,6 +119,7 @@ final class R2CredentialStore {
             accountID: _accountID,
             bucket: _bucket,
             publicBaseURL: _publicBaseURL,
+            useDirectLinks: _useDirectLinks,
             accessKeyID: _accessKeyID,
             secretAccessKey: _secretAccessKey,
             enabled: _enabled
@@ -117,6 +130,7 @@ final class R2CredentialStore {
         _accountID = defaults.string(forKey: Keys.accountID) ?? ""
         _bucket = defaults.string(forKey: Keys.bucket) ?? ""
         _publicBaseURL = defaults.string(forKey: Keys.publicBaseURL) ?? ""
+        _useDirectLinks = defaults.bool(forKey: Keys.useDirectLinks)
         _enabled = defaults.bool(forKey: Keys.enabled)
 
         let accessKey = Self.getKeychainItem(key: Keys.accessKeyID)

--- a/Sources/Sharing/R2Uploader.swift
+++ b/Sources/Sharing/R2Uploader.swift
@@ -309,12 +309,28 @@ final class R2Uploader {
         progress: @escaping @Sendable (Double) -> Void
     ) async throws -> URL {
         let id = ShareBundle.slug(for: itemID)
+        // Reject a bad origin up front so it fails instantly, rather than after the whole file has already gone up.
         guard let pageURL = ShareBundle.pageURL(id: id, publicBaseURL: credentials.publicBaseURL) else {
-            throw R2UploadError(message: "The Public Base URL must start with https:// to build a share link.")
+            throw R2UploadError(message: "The Public Bucket URL must start with https:// to build a share link.")
         }
 
         let contents = await ShareBundle.make(id: id, fileURL: fileURL, title: title)
         let prefix = ShareBundle.objectPrefix(id: id)
+
+        // A direct link points at the media object, whose filename only exists once the bundle is made.
+        let shareURL: URL
+        if credentials.useDirectLinks {
+            guard let directURL = ShareBundle.directURL(
+                id: id,
+                filename: contents.mediaFilename,
+                publicBaseURL: credentials.publicBaseURL
+            ) else {
+                throw R2UploadError(message: "Could not build a direct link to \(contents.mediaFilename).")
+            }
+            shareURL = directURL
+        } else {
+            shareURL = pageURL
+        }
 
         try await putObject(
             key: prefix + contents.mediaFilename,
@@ -345,7 +361,7 @@ final class R2Uploader {
         )
 
         progress(1)
-        return pageURL
+        return shareURL
     }
 
     private enum Payload: Sendable {

--- a/Sources/Sharing/R2Uploader.swift
+++ b/Sources/Sharing/R2Uploader.swift
@@ -309,7 +309,6 @@ final class R2Uploader {
         progress: @escaping @Sendable (Double) -> Void
     ) async throws -> URL {
         let id = ShareBundle.slug(for: itemID)
-        // Reject a bad origin up front so it fails instantly, rather than after the whole file has already gone up.
         guard let pageURL = ShareBundle.pageURL(id: id, publicBaseURL: credentials.publicBaseURL) else {
             throw R2UploadError(message: "The Public Bucket URL must start with https:// to build a share link.")
         }
@@ -317,7 +316,6 @@ final class R2Uploader {
         let contents = await ShareBundle.make(id: id, fileURL: fileURL, title: title)
         let prefix = ShareBundle.objectPrefix(id: id)
 
-        // A direct link points at the media object, whose filename only exists once the bundle is made.
         let shareURL: URL
         if credentials.useDirectLinks {
             guard let directURL = ShareBundle.directURL(

--- a/Sources/Sharing/ShareManifest.swift
+++ b/Sources/Sharing/ShareManifest.swift
@@ -169,11 +169,28 @@ extension ShareBundle {
 
     nonisolated static func objectPrefix(id: String) -> String { "s/\(id)/" }
 
-    nonisolated static func pageURL(id: String, publicBaseURL: String) -> URL? {
+    /// Accepts an origin pasted with or without a trailing slash. Returns nil for anything that is not https, because the viewer refuses non-https origins and a direct link over http would be no better.
+    nonisolated private static func normalizedOrigin(_ publicBaseURL: String) -> String? {
         let origin = publicBaseURL
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         guard origin.lowercased().hasPrefix("https://") else { return nil }
+        return origin
+    }
+
+    /// A path segment must not smuggle in a separator, so drop "/" from the allowed set even though sanitizedFilename already strips it.
+    private nonisolated static let pathSegmentAllowed = CharacterSet.urlPathAllowed
+        .subtracting(CharacterSet(charactersIn: "/"))
+
+    /// Links straight at the uploaded object rather than the viewer page, for people who would rather their shares not route through bettershot.site.
+    nonisolated static func directURL(id: String, filename: String, publicBaseURL: String) -> URL? {
+        guard !filename.isEmpty, let origin = normalizedOrigin(publicBaseURL) else { return nil }
+        guard let segment = filename.addingPercentEncoding(withAllowedCharacters: pathSegmentAllowed) else { return nil }
+        return URL(string: "\(origin)/\(objectPrefix(id: id))\(segment)")
+    }
+
+    nonisolated static func pageURL(id: String, publicBaseURL: String) -> URL? {
+        guard let origin = normalizedOrigin(publicBaseURL) else { return nil }
 
         let encodedOrigin = Data(origin.utf8)
             .base64EncodedString()

--- a/Sources/Sharing/ShareManifest.swift
+++ b/Sources/Sharing/ShareManifest.swift
@@ -169,7 +169,7 @@ extension ShareBundle {
 
     nonisolated static func objectPrefix(id: String) -> String { "s/\(id)/" }
 
-    /// Accepts an origin pasted with or without a trailing slash. Returns nil for anything that is not https, because the viewer refuses non-https origins and a direct link over http would be no better.
+    /// Tolerates a pasted trailing slash. Returns nil for anything that is not https.
     nonisolated private static func normalizedOrigin(_ publicBaseURL: String) -> String? {
         let origin = publicBaseURL
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -178,9 +178,7 @@ extension ShareBundle {
         return origin
     }
 
-    /// Why a pasted Public Bucket URL will not work. The uploader rejects the same
-    /// strings when a share is already in flight, so catching them in Settings is the
-    /// difference between a fixable typo and a capture that fails to upload.
+    /// Why a pasted Public Bucket URL cannot be used, and what to tell the user.
     enum PublicBaseURLProblem: Equatable {
         case empty
         case notHTTPS
@@ -201,24 +199,20 @@ extension ShareBundle {
         }
     }
 
-    /// Returns nil when the address is usable. A path is deliberately allowed, because
-    /// a bucket bound under a subfolder is a normal setup.
+    /// Returns nil when the address is usable. A path is allowed: a bucket can be bound under a subfolder.
     nonisolated static func validatePublicBaseURL(_ publicBaseURL: String) -> PublicBaseURLProblem? {
         let trimmed = publicBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return .empty }
-        // Checked before normalizedOrigin, which strips the trailing slashes off a bare
-        // "https://" and would then blame the scheme for a missing domain.
+        // Before normalizedOrigin, which trims a bare "https://" down to "https:" and would blame the scheme.
         guard trimmed.lowercased().hasPrefix("https://") else { return .notHTTPS }
         guard let components = URLComponents(string: trimmed) else { return .invalidHost }
         guard components.query == nil, components.fragment == nil else { return .hasQueryOrFragment }
         guard let host = components.host, isHostname(host) else { return .invalidHost }
-        // Whatever is accepted here has to survive the normalisation the links go through.
         guard normalizedOrigin(trimmed) != nil else { return .invalidHost }
         return nil
     }
 
-    /// A public bucket always sits on a dotted domain, so a single label like
-    /// "localhost" is a typo rather than a setup worth supporting.
+    /// A public bucket is always on a dotted domain, so a single label is a typo.
     nonisolated private static func isHostname(_ host: String) -> Bool {
         let labels = host.split(separator: ".", omittingEmptySubsequences: false)
         guard labels.count >= 2 else { return false }
@@ -229,11 +223,11 @@ extension ShareBundle {
         }
     }
 
-    /// A path segment must not smuggle in a separator, so drop "/" from the allowed set even though sanitizedFilename already strips it.
+    /// Drops "/" so a filename cannot open a new path segment.
     private nonisolated static let pathSegmentAllowed = CharacterSet.urlPathAllowed
         .subtracting(CharacterSet(charactersIn: "/"))
 
-    /// Links straight at the uploaded object rather than the viewer page, for people who would rather their shares not route through bettershot.site.
+    /// Links straight at the uploaded object instead of the viewer page.
     nonisolated static func directURL(id: String, filename: String, publicBaseURL: String) -> URL? {
         guard !filename.isEmpty, let origin = normalizedOrigin(publicBaseURL) else { return nil }
         guard let segment = filename.addingPercentEncoding(withAllowedCharacters: pathSegmentAllowed) else { return nil }

--- a/Sources/Sharing/ShareManifest.swift
+++ b/Sources/Sharing/ShareManifest.swift
@@ -178,6 +178,57 @@ extension ShareBundle {
         return origin
     }
 
+    /// Why a pasted Public Bucket URL will not work. The uploader rejects the same
+    /// strings when a share is already in flight, so catching them in Settings is the
+    /// difference between a fixable typo and a capture that fails to upload.
+    enum PublicBaseURLProblem: Equatable {
+        case empty
+        case notHTTPS
+        case invalidHost
+        case hasQueryOrFragment
+
+        nonisolated var message: String {
+            switch self {
+            case .empty:
+                return "Add the public address of your bucket, like https://share.example.com."
+            case .notHTTPS:
+                return "The address has to start with https:// - a public bucket is served over HTTPS."
+            case .invalidHost:
+                return "That is not a complete address. Use the domain your bucket is served from, like https://share.example.com."
+            case .hasQueryOrFragment:
+                return "Remove everything after the address - a share link is built by adding to it."
+            }
+        }
+    }
+
+    /// Returns nil when the address is usable. A path is deliberately allowed, because
+    /// a bucket bound under a subfolder is a normal setup.
+    nonisolated static func validatePublicBaseURL(_ publicBaseURL: String) -> PublicBaseURLProblem? {
+        let trimmed = publicBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .empty }
+        // Checked before normalizedOrigin, which strips the trailing slashes off a bare
+        // "https://" and would then blame the scheme for a missing domain.
+        guard trimmed.lowercased().hasPrefix("https://") else { return .notHTTPS }
+        guard let components = URLComponents(string: trimmed) else { return .invalidHost }
+        guard components.query == nil, components.fragment == nil else { return .hasQueryOrFragment }
+        guard let host = components.host, isHostname(host) else { return .invalidHost }
+        // Whatever is accepted here has to survive the normalisation the links go through.
+        guard normalizedOrigin(trimmed) != nil else { return .invalidHost }
+        return nil
+    }
+
+    /// A public bucket always sits on a dotted domain, so a single label like
+    /// "localhost" is a typo rather than a setup worth supporting.
+    nonisolated private static func isHostname(_ host: String) -> Bool {
+        let labels = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard labels.count >= 2 else { return false }
+        return labels.allSatisfy { label in
+            !label.isEmpty
+                && label.first != "-" && label.last != "-"
+                && label.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") }
+        }
+    }
+
     /// A path segment must not smuggle in a separator, so drop "/" from the allowed set even though sanitizedFilename already strips it.
     private nonisolated static let pathSegmentAllowed = CharacterSet.urlPathAllowed
         .subtracting(CharacterSet(charactersIn: "/"))

--- a/Tests/ShareLinkCheck.swift
+++ b/Tests/ShareLinkCheck.swift
@@ -52,7 +52,6 @@ enum ShareLinkCheck {
             fatalError("an https origin should produce a direct URL")
         }
 
-        // The whole point of a direct link is that it lands on the key we uploaded, so assert against that key rather than a hand-written string.
         let key = ShareBundle.objectPrefix(id: slug) + "clip.mp4"
         expect(url.absoluteString == "https://cdn.example.com/\(key)", "direct URL must match the uploaded object key: \(url)")
         expect(!url.absoluteString.contains(ShareBundle.pageBaseURL), "a direct link must not route through the viewer: \(url)")
@@ -70,8 +69,6 @@ enum ShareLinkCheck {
         expect(ShareBundle.validatePublicBaseURL("   ") == .empty, "whitespace only is still empty")
         expect(ShareBundle.validatePublicBaseURL("cdn.example.com") == .notHTTPS, "a bare domain has no scheme")
         expect(ShareBundle.validatePublicBaseURL("http://cdn.example.com") == .notHTTPS, "http is rejected")
-        // Half-typed input: normalizedOrigin strips the trailing slashes off this and
-        // would blame the scheme, so the scheme check has to run before it.
         expect(ShareBundle.validatePublicBaseURL("https://") == .invalidHost, "a scheme with no domain is a missing host, not a missing scheme")
         expect(ShareBundle.validatePublicBaseURL("https://localhost") == .invalidHost, "a single label is not a public bucket domain")
         expect(ShareBundle.validatePublicBaseURL("https://cdn.example.com?x=1") == .hasQueryOrFragment, "a query would land in the middle of the key")
@@ -86,8 +83,6 @@ enum ShareLinkCheck {
         ]
         for origin in valid {
             expect(ShareBundle.validatePublicBaseURL(origin) == nil, "should be accepted: \(origin)")
-            // The point of accepting an address is that both link shapes can be built
-            // from it, so the validator must never green-light one the builders reject.
             expect(ShareBundle.directURL(id: "abc", filename: "a.png", publicBaseURL: origin) != nil, "accepted origin must build a direct link: \(origin)")
             expect(ShareBundle.pageURL(id: "abc", publicBaseURL: origin) != nil, "accepted origin must build a viewer link: \(origin)")
         }

--- a/Tests/ShareLinkCheck.swift
+++ b/Tests/ShareLinkCheck.swift
@@ -63,6 +63,41 @@ enum ShareLinkCheck {
         expect(!spaced.absoluteString.contains(" "), "spaces must be percent-encoded: \(spaced)")
     }
 
+    static func checkPublicBaseURLValidation() {
+        typealias Problem = ShareBundle.PublicBaseURLProblem
+
+        expect(ShareBundle.validatePublicBaseURL("") == .empty, "an empty field is empty, not malformed")
+        expect(ShareBundle.validatePublicBaseURL("   ") == .empty, "whitespace only is still empty")
+        expect(ShareBundle.validatePublicBaseURL("cdn.example.com") == .notHTTPS, "a bare domain has no scheme")
+        expect(ShareBundle.validatePublicBaseURL("http://cdn.example.com") == .notHTTPS, "http is rejected")
+        // Half-typed input: normalizedOrigin strips the trailing slashes off this and
+        // would blame the scheme, so the scheme check has to run before it.
+        expect(ShareBundle.validatePublicBaseURL("https://") == .invalidHost, "a scheme with no domain is a missing host, not a missing scheme")
+        expect(ShareBundle.validatePublicBaseURL("https://localhost") == .invalidHost, "a single label is not a public bucket domain")
+        expect(ShareBundle.validatePublicBaseURL("https://cdn.example.com?x=1") == .hasQueryOrFragment, "a query would land in the middle of the key")
+        expect(ShareBundle.validatePublicBaseURL("https://cdn.example.com#top") == .hasQueryOrFragment, "so would a fragment")
+
+        let valid = [
+            "https://cdn.example.com",
+            "https://cdn.example.com/",
+            "  https://cdn.example.com  ",
+            "https://pub-1a2b3c.r2.dev",
+            "https://cdn.example.com/files",
+        ]
+        for origin in valid {
+            expect(ShareBundle.validatePublicBaseURL(origin) == nil, "should be accepted: \(origin)")
+            // The point of accepting an address is that both link shapes can be built
+            // from it, so the validator must never green-light one the builders reject.
+            expect(ShareBundle.directURL(id: "abc", filename: "a.png", publicBaseURL: origin) != nil, "accepted origin must build a direct link: \(origin)")
+            expect(ShareBundle.pageURL(id: "abc", publicBaseURL: origin) != nil, "accepted origin must build a viewer link: \(origin)")
+        }
+
+        let problems: [Problem] = [.empty, .notHTTPS, .invalidHost, .hasQueryOrFragment]
+        for problem in problems {
+            expect(!problem.message.isEmpty, "every problem needs something to show the user")
+        }
+    }
+
     static func checkManifestEncoding() throws {
         let manifest = ShareManifest(
             version: ShareManifest.currentVersion,
@@ -108,6 +143,7 @@ enum ShareLinkCheck {
         checkSlug()
         checkPageURL()
         checkDirectURL()
+        checkPublicBaseURLValidation()
         try checkManifestEncoding()
         checkSanitizedFilename()
         print("ShareLinkCheck: all assertions passed")

--- a/Tests/ShareLinkCheck.swift
+++ b/Tests/ShareLinkCheck.swift
@@ -42,6 +42,27 @@ enum ShareLinkCheck {
         expect(decodeBase64URL(encoded) == "https://cdn.example.com", "b should round-trip to the trimmed origin")
     }
 
+    static func checkDirectURL() {
+        let slug = "abcDEF-123_xyz"
+        expect(ShareBundle.directURL(id: slug, filename: "clip.mp4", publicBaseURL: "http://cdn.example.com") == nil, "http origins must be rejected")
+        expect(ShareBundle.directURL(id: slug, filename: "clip.mp4", publicBaseURL: "") == nil, "empty origins must be rejected")
+        expect(ShareBundle.directURL(id: slug, filename: "", publicBaseURL: "https://cdn.example.com") == nil, "an empty filename has nothing to link to")
+
+        guard let url = ShareBundle.directURL(id: slug, filename: "clip.mp4", publicBaseURL: "https://cdn.example.com/") else {
+            fatalError("an https origin should produce a direct URL")
+        }
+
+        // The whole point of a direct link is that it lands on the key we uploaded, so assert against that key rather than a hand-written string.
+        let key = ShareBundle.objectPrefix(id: slug) + "clip.mp4"
+        expect(url.absoluteString == "https://cdn.example.com/\(key)", "direct URL must match the uploaded object key: \(url)")
+        expect(!url.absoluteString.contains(ShareBundle.pageBaseURL), "a direct link must not route through the viewer: \(url)")
+
+        guard let spaced = ShareBundle.directURL(id: slug, filename: "my clip.mp4", publicBaseURL: "https://cdn.example.com") else {
+            fatalError("a filename needing encoding should still produce a URL")
+        }
+        expect(!spaced.absoluteString.contains(" "), "spaces must be percent-encoded: \(spaced)")
+    }
+
     static func checkManifestEncoding() throws {
         let manifest = ShareManifest(
             version: ShareManifest.currentVersion,
@@ -86,6 +107,7 @@ enum ShareLinkCheck {
     static func main() throws {
         checkSlug()
         checkPageURL()
+        checkDirectURL()
         try checkManifestEncoding()
         checkSanitizedFilename()
         print("ShareLinkCheck: all assertions passed")


### PR DESCRIPTION
## Why

BetterShot uploads to the user's own Cloudflare R2 bucket, but the link it copies doesn't point there. It points at a viewer page on `bettershot.site`, which reads the manifest and renders the file:

```
viewer   https://bettershot.site/s/<id>?b=<base64url origin>
object   https://share.example.com/s/<id>/screenshot.png
```

That's a good default and it stays the default. But it does mean every share depends on `bettershot.site` staying up, and it routes a file that already lives on the user's own domain through a third party. For someone who went to the trouble of setting up R2 specifically to own their sharing, the link is the one piece they can't own.

There's a practical side too. A viewer link is an HTML page, so it doesn't work anywhere a raw file URL is expected:

- `![](url)` in markdown, a README, or a docs site
- `<img src>` / `<video src>` embeds
- Slack, Discord and iMessage unfurling to an inline preview rather than a link card
- `curl`, `wget`, or anything else that expects the bytes to be at the URL

Today the only workaround is to open the viewer, right-click the media and copy *that* address by hand, on every single share.

## What

A **Copy direct file links** toggle in Settings › Sharing. Turned on, the copied link is the object in your own bucket instead of the viewer page.

**Off by default**, so existing installs keep getting viewer links and nothing changes for anyone who doesn't go looking for it.

### The trade-off, stated plainly

The viewer page is genuinely better for most people, which is why it remains the default:

|  | Viewer link | Direct link |
|---|---|---|
| Title, poster, download button | yes | no |
| Filename hidden behind a random id | yes | no, it's in the URL |
| Works as `<img src>` / in markdown | no | yes |
| Depends on `bettershot.site` | yes | no |

The settings footer spells this out at the point of decision, so it reads as an informed choice rather than a mystery switch.

## Implementation notes

- `ShareBundle.directURL(id:filename:publicBaseURL:)` builds the URL from `objectPrefix(id:)` — the same helper that produces the upload key — so the link can't drift from where the file actually went.
- The https-only origin check moved into `normalizedOrigin`, now shared by `pageURL` and `directURL` instead of living only in the former. Same behaviour as before: a pasted trailing slash is tolerated, `http://` is rejected. A direct link over http would be no better than a viewer over http, so the rule holds for both.
- The filename is percent-encoded as one path segment, with `/` subtracted from `.urlPathAllowed`. `sanitizedFilename` already strips separators, so this is belt-and-braces against a name reshaping the key.
- **`Public URL` is relabelled `Public Bucket URL`.** In viewer mode that field is almost decorative — it gets base64'd into a query parameter. In direct mode it *is* the origin the file is served from. The old label undersold what it does, and the footer now says outright that this is where your files are stored and served.
- **The poster and manifest are still uploaded in direct mode.** The bundle stays complete, so the viewer page for the same id keeps working and the toggle stays purely a choice about which link lands on your clipboard, not a one-way change to what got uploaded. If you'd rather direct mode skip those two objects and be leaner, that's a small change — say the word.

## Validating the address

Pushed a second commit for this, because the toggle made an existing gap load-bearing.

`Test Connection` never touches the Public Bucket URL — it exercises the account, keys and bucket — and `isConfigured` only checks the field is non-empty. So a field containing nothing but `https://` reported **Connected**, and the first sign of trouble was a share failing to upload. That was survivable when the field was only base64'd into a viewer link. It isn't once a direct link is built straight from it.

`ShareBundle.validatePublicBaseURL` now lives next to `normalizedOrigin`, so Settings and the uploader can't drift on what counts as usable:

| Input | Result |
|---|---|
| `https://` | not a complete address |
| `http://cdn.example.com`, `cdn.example.com` | must start with `https://` |
| `https://localhost` | not a complete address — a public bucket is always on a dotted domain |
| `https://cdn.example.com?x=1` | remove the query; the key is appended to this |
| `https://cdn.example.com/files` | **accepted** — a bucket under a subpath is a normal setup |

One ordering detail that's easy to get wrong: the scheme check has to run *before* `normalizedOrigin`, which strips the trailing slashes off a bare `https://` and would then blame the scheme for what is really a missing domain.

### Behaviour of the switch

Direct links depend on that address and nothing else, so the switch turns itself off when the address stops working — both when the field is edited and when Settings is opened against a setting stored in an earlier session. It does that **silently**: the switch moving is the feedback, and the message is reserved for a tap, where the user actually asked for something.

The switch is also no longer gated on `isConfigured`. An empty URL already fails that check, so the switch was greyed out in exactly the case where it most needed to explain itself. `Upload when I share` keeps its original gating.

## Testing

`Tests/ShareLinkCheck.swift` gains `checkDirectURL()`, covering:

- `http://` origins, an empty origin, and an empty filename all return `nil`
- a pasted trailing slash still produces a valid URL
- the result equals `objectPrefix(id:) + filename` — asserted against the real key helper rather than a hand-written string, so the test fails if the upload key and the link ever diverge
- the link never contains `pageBaseURL`, since routing through the viewer is the exact thing the toggle exists to avoid
- a filename with a space comes out percent-encoded

`checkPublicBaseURLValidation()` covers the table above, and asserts the converse too: every address the validator accepts must actually build both a direct link and a viewer link, so it can never green-light an origin the builders reject.

Verified locally: `ShareLinkCheck` passes, and `make release` (what CI runs) builds clean.

## Screenshots
New section of the menu for toggle the direct link:
<img width="1166" height="754" alt="BetterShot_Annotated_8188B0" src="https://github.com/user-attachments/assets/99280a20-e2e6-448d-9762-48c4e90cac13" />

Popup after sharing with custom url:
<img width="1003" height="361" alt="image" src="https://github.com/user-attachments/assets/ea0ca743-1a7a-4012-8ae6-4537613343aa" />

