### PR TITLE
fix: keep deck copy out of the save folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,8 @@ User presses ⌘⇧4 (or picks Region on the bar)
 
 With **Keep screenshots in the deck until saved** on, the capture is staged in
 `DeckStaging` instead of history and only promoted to the save folder when the
-user saves, copies, drags, pins, or opens it.
+user saves, drags, pins, or opens it. Copy only writes to the clipboard and
+discards the unsaved card; it does not add the capture to the save folder or Library.
 
 All windows (editors, settings, preview deck, toasts, pinned screenshots) open
 on the screen where the action originated, not the primary display.

--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -377,7 +377,6 @@ struct PreviewCardView: View {
                         } else {
                             try ScreenshotFileActions.copyImageToClipboard(from: url)
                         }
-                        DeckStaging.promote(url)
                         overlay.remove(url)
                     } catch {
                         // Reading the file can fail if the capture moved or was deleted


### PR DESCRIPTION
Closes #134.

Copy on an unsaved screenshot's preview card also called `DeckStaging.promote`, which wrote the capture to the configured save folder and imported it into the Library. Remove that call: Copy writes the existing image data to the clipboard, then dismisses and discards the unsaved card. Save, drag, Pin, and Annotate keep their existing behavior. With deck staging disabled, captures are still saved by the capture pipeline as before.

Validation: type-checked all app sources with the settings from `project.yml` and the real DockProgress 5.0.0 module. The existing standalone checks pass; ColorGradeCheck and UpdaterTrustCheck needed to run outside the local sandbox to access macOS APIs. No full Xcode installation here, so the release build is left to CI.

Manual check still needed: with **Keep screenshots in the deck until saved** on, capture, click Copy, and paste into an image-capable app; confirm the save folder and Library do not gain an item. Capture again and click Save; confirm it is saved normally.
