### PR TITLE
feat: support fractional and slow-motion clip speeds

### DIFF
--- a/Sources/BetterShot/RecordingClipTimeline.swift
+++ b/Sources/BetterShot/RecordingClipTimeline.swift
@@ -11,13 +11,13 @@ import Foundation
 
 nonisolated struct RecordingClipSegment: Identifiable, Codable, Equatable, Sendable {
     static let minimumDuration: TimeInterval = 0.12
-    static let minimumSpeed: Double = 1
+    static let minimumSpeed: Double = 0.25
     static let maximumSpeed: Double = 8
 
     var id: UUID
     var sourceStart: TimeInterval
     var sourceEnd: TimeInterval
-    /// Playback speed multiplier applied only to this clip (1...8). Baked
+    /// Playback speed multiplier applied only to this clip (0.25...8). Baked
     /// into the composition via `AVMutableComposition.scaleTimeRange`, so
     /// video and audio speed up together and stay in sync.
     var speed: Double

--- a/Sources/BetterShot/RecordingPointerTimeline.swift
+++ b/Sources/BetterShot/RecordingPointerTimeline.swift
@@ -341,7 +341,7 @@ nonisolated struct PointerTimeline: Sendable {
             if sourceTime >= segment.sourceStart,
                sourceTime < segment.sourceEnd {
                 return editorStart
-                    + (sourceTime - segment.sourceStart) / max(segment.speed, 1)
+                    + (sourceTime - segment.sourceStart) / max(segment.speed, RecordingClipSegment.minimumSpeed)
             }
             editorStart += segment.editorDuration
         }

--- a/Sources/BetterShot/RecordingStudioWindow.swift
+++ b/Sources/BetterShot/RecordingStudioWindow.swift
@@ -3190,14 +3190,14 @@ private struct StudioInspector: View {
                 "Speed",
                 value: Binding(
                     get: { CGFloat(clip.speed) },
-                    set: { model.setClipSpeed(Double($0.rounded()), forClipID: clip.id) }
+                    set: { model.setClipSpeed(Double($0), forClipID: clip.id) }
                 ),
                 range: CGFloat(RecordingClipSegment.minimumSpeed)...CGFloat(RecordingClipSegment.maximumSpeed),
-                format: .magnification(fractionDigits: 0)
+                format: .magnification(fractionDigits: 2)
             )
 
             if clip.speed != 1 {
-                Text("Plays this clip \(Int(clip.speed))× faster. Audio speeds up with it.")
+                Text("Plays this clip at \(clip.speed.formatted(.number.precision(.fractionLength(0...2))))× speed. Audio stays in sync.")
                     .font(.inspectorLabel)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Sources/BetterShot/RecordingStudioWindow.swift
+++ b/Sources/BetterShot/RecordingStudioWindow.swift
@@ -2609,6 +2609,7 @@ private enum StudioTranscriptTab: CaseIterable, Identifiable {
 
 private struct StudioInspector: View {
     @Bindable var model: RecordingStudioModel
+    @State private var clipSpeedDraft: (id: UUID, speed: Double)?
     @State private var selectedTab: StudioInspectorTab = .background
     @State private var wallpaperStore = AnnotationWallpaperStore.shared
     @State private var stylePresetStore = RecordingStudioStylePresetStore.shared
@@ -3185,19 +3186,28 @@ private struct StudioInspector: View {
     // MARK: Selected clip
 
     private func selectedClipControls(for clip: RecordingClipSegment) -> some View {
-        VStack(alignment: .leading, spacing: InspectorMetrics.rowSpacing) {
+        let speed = clipSpeedDraft.flatMap { $0.id == clip.id ? $0.speed : nil } ?? clip.speed
+        return VStack(alignment: .leading, spacing: InspectorMetrics.rowSpacing) {
             InspectorSlider(
                 "Speed",
                 value: Binding(
-                    get: { CGFloat(clip.speed) },
-                    set: { model.setClipSpeed(Double($0), forClipID: clip.id) }
+                    get: { CGFloat(speed) },
+                    set: { clipSpeedDraft = (clip.id, Double($0)) }
                 ),
                 range: CGFloat(RecordingClipSegment.minimumSpeed)...CGFloat(RecordingClipSegment.maximumSpeed),
-                format: .magnification(fractionDigits: 2)
+                format: .magnification(fractionDigits: 2),
+                onEditingChanged: { editing in
+                    if editing {
+                        clipSpeedDraft = (clip.id, clip.speed)
+                    } else if let draft = clipSpeedDraft, draft.id == clip.id {
+                        clipSpeedDraft = nil
+                        model.setClipSpeed(draft.speed, forClipID: draft.id)
+                    }
+                }
             )
 
-            if clip.speed != 1 {
-                Text("Plays this clip at \(clip.speed.formatted(.number.precision(.fractionLength(0...2))))× speed. Audio stays in sync.")
+            if speed != 1 {
+                Text("Plays this clip at \(speed.formatted(.number.precision(.fractionLength(0...2))))× speed. Audio stays in sync.")
                     .font(.inspectorLabel)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Tests/ClipSpeedCheck.sources
+++ b/Tests/ClipSpeedCheck.sources
@@ -1,0 +1,1 @@
+Sources/BetterShot/RecordingClipTimeline.swift

--- a/Tests/ClipSpeedCheck.swift
+++ b/Tests/ClipSpeedCheck.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+@main
+struct ClipSpeedCheck {
+    static func main() throws {
+        for speed in [0.25, 0.5, 1.25, 1.5, 2.5, 8] {
+            let clip = RecordingClipSegment(sourceStart: 2, sourceEnd: 12, speed: speed)
+            let timeline = RecordingClipTimeline(segments: [clip]).normalized(to: 12)
+            assert(timeline.segments[0].speed == speed)
+            assert(abs(timeline.duration - 10 / speed) < 0.000_001)
+            assert(abs(timeline.sourceTime(at: 5 / speed) - 7) < 0.000_001)
+            assert(abs(timeline.editorTime(forSourceTime: 7)! - 5 / speed) < 0.000_001)
+            let split = timeline.split(at: 5 / speed)!.timeline
+            assert(split.segments.allSatisfy { $0.speed == speed })
+            assert(abs(split.duration - timeline.duration) < 0.000_001)
+            let slices = timeline.slices(overlapping: 4, sourceEnd: 8)
+            assert(abs(slices[0].editorStart - 2 / speed) < 0.000_001)
+            assert(abs(slices[0].editorEnd - 6 / speed) < 0.000_001)
+            let data = try JSONEncoder().encode(timeline)
+            let decoded = try JSONDecoder().decode(RecordingClipTimeline.self, from: data)
+            assert(decoded.normalized(to: 12) == timeline)
+        }
+        for speed in [0, -1, Double.nan, Double.infinity, 99] {
+            let clip = RecordingClipSegment(sourceStart: 0, sourceEnd: 10, speed: speed)
+            let normalized = RecordingClipTimeline(segments: [clip]).normalized(to: 10)
+            assert((0.25...8).contains(normalized.segments[0].speed))
+            assert(normalized.duration.isFinite)
+        }
+        print("ClipSpeedCheck: дробные скорости, замедление и сохранение таймлайна проверены")
+    }
+}

--- a/Tests/ClipSpeedCheck.swift
+++ b/Tests/ClipSpeedCheck.swift
@@ -26,6 +26,6 @@ struct ClipSpeedCheck {
             assert((0.25...8).contains(normalized.segments[0].speed))
             assert(normalized.duration.isFinite)
         }
-        print("ClipSpeedCheck: дробные скорости, замедление и сохранение таймлайна проверены")
+        print("ClipSpeedCheck: fractional speeds, slow motion, and timeline preservation verified")
     }
 }


### PR DESCRIPTION
Closes #137.

The clip speed control rounded every value to a whole number, and timeline normalization clamped slower playback to 1×. Allow speeds from 0.25× to 8×, keep fractional values from the existing editable inspector control, and display two decimal places. The description now works for both slower and faster playback.

Keep a draft value during slider dragging and apply the speed once when editing ends, so a single gesture creates one undo entry and one player rebuild. Typed values and keyboard adjustments use the same commit boundary.

Also remove the pointer timeline's separate 1× floor: otherwise slow-motion video and click/cursor events would run on different clocks. The existing composition builder already retimes audio and video together; document serialization, splitting, and trimming preserve the fractional speed.

Validation: `ClipSpeedCheck` compiles the production timeline and checks 0.25, 0.5, 1.25, 1.5, 2.5, and 8× playback, source/editor time mapping, splitting, slices, JSON round trips, and invalid-speed normalization. All app sources type-check with the project settings and the real DockProgress dependency. Full release build is delegated to CI because this machine has Command Line Tools, not Xcode.

Manual playback/export check still needed: type 0.5× and 1.25×, scrub and split the clip, reopen it, and export; verify audio, camera, pointer, and click timing stay aligned.
