### PR TITLE
feat: add a shortcut for direct region recording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,10 @@ on the screen where the action originated, not the primary display.
 
 ### Recording flow
 
+Settings > Shortcuts > **Record Region** starts area selection directly on the
+display containing the pointer. Its suggested shortcut is ⌥⇧⌘2, disabled by
+default and rebindable. It uses the normal recording countdown and capture inputs.
+
 ```
 User presses ⌘⇧2 → RecordingPickerBar (screen / window / area / screenshot actions)
   → RecordingCaptureEntry.recordFullscreen / recordWindow / recordArea

--- a/Sources/BetterShot/RecordingCaptureEntry.swift
+++ b/Sources/BetterShot/RecordingCaptureEntry.swift
@@ -2,6 +2,26 @@ import Foundation
 import ScreenCaptureKit
 
 enum RecordingCaptureEntry {
+    static func recordAreaOnActiveDisplay() async {
+        guard !ScreenRecordingManager.shared.isActive else { return }
+        let displayID = ActiveDisplayResolver.activeDisplayID(preferPointer: true)
+        let catalog = RecordingSourceCatalog.shared
+        await catalog.refresh()
+        guard !ScreenRecordingManager.shared.isActive else { return }
+        guard catalog.errorMessage == nil,
+              let display = catalog.displays.first(where: { $0.displayID == displayID })
+                ?? catalog.displays.first else {
+            ToastWindow.shared.show(
+                title: "Couldn't start recording",
+                message: catalog.errorMessage ?? "No display is available to record.",
+                systemIcon: "exclamationmark.triangle"
+            )
+            return
+        }
+        RecordingBarPresenter.shared.hide()
+        recordArea(display)
+    }
+
     static func recordFullscreen(_ display: SCDisplay) {
         Task {
             await CaptureCountdownPresenter.shared.runIfNeeded(

--- a/Sources/Capture/CaptureOrchestrator.swift
+++ b/Sources/Capture/CaptureOrchestrator.swift
@@ -55,7 +55,7 @@ final class CaptureOrchestrator {
             await performOCR()
         case .colorPicker:
             await performColorPick()
-        case .recording:
+        case .recording, .recordingArea:
             break
         }
     }

--- a/Sources/Services/ShortcutService.swift
+++ b/Sources/Services/ShortcutService.swift
@@ -31,6 +31,7 @@ final class ShortcutService {
         static let defaultOCR = Shortcut(keyCode: UInt32(kVK_ANSI_O), modifiers: UInt32(cmdKey | shiftKey), enabled: true)
         static let defaultColorPicker = Shortcut(keyCode: UInt32(kVK_ANSI_C), modifiers: UInt32(cmdKey | shiftKey), enabled: true)
         static let defaultRecording = Shortcut(keyCode: UInt32(kVK_ANSI_2), modifiers: UInt32(cmdKey | shiftKey), enabled: true)
+        static let defaultRecordingArea = Shortcut(keyCode: UInt32(kVK_ANSI_2), modifiers: UInt32(cmdKey | shiftKey | optionKey), enabled: false)
     }
 
     enum Action: UInt32, CaseIterable {
@@ -40,6 +41,7 @@ final class ShortcutService {
         case ocr = 4
         case colorPicker = 5
         case recording = 6
+        case recordingArea = 7
     }
 
     // MARK: - Registration (CGEvent tap — intercepts system shortcuts)
@@ -84,6 +86,7 @@ final class ShortcutService {
             (.ocr, service.loadShortcut(for: .ocr) ?? .defaultOCR),
             (.colorPicker, service.loadShortcut(for: .colorPicker) ?? .defaultColorPicker),
             (.recording, service.loadShortcut(for: .recording) ?? .defaultRecording),
+            (.recordingArea, service.loadShortcut(for: .recordingArea) ?? .defaultRecordingArea),
         ]
     }
 
@@ -163,6 +166,8 @@ final class ShortcutService {
                     if action == .recording {
                         guard !ScreenRecordingManager.shared.isActive else { return }
                         RecordingBarPresenter.shared.togglePicker()
+                    } else if action == .recordingArea {
+                        await RecordingCaptureEntry.recordAreaOnActiveDisplay()
                     } else {
                         await CaptureOrchestrator.shared.performCapture(action, on: mouseScreen)
                     }
@@ -183,6 +188,7 @@ extension ShortcutService.Action {
         case .ocr: .defaultOCR
         case .colorPicker: .defaultColorPicker
         case .recording: .defaultRecording
+        case .recordingArea: .defaultRecordingArea
         case .window: nil
         }
     }

--- a/Sources/Settings/PreferencesView.swift
+++ b/Sources/Settings/PreferencesView.swift
@@ -871,6 +871,7 @@ struct ShortcutSettingsTab: View {
         ("OCR", "Read the text out of any region", .ocr),
         ("Pick Color", "Sample a color from anywhere on screen", .colorPicker),
         ("Record Screen", "Open the recording bar", .recording),
+        ("Record Region", "Select an area and start recording directly", .recordingArea),
     ]
 
     var body: some View {

--- a/Tests/RecordRegionShortcutCheck.sources
+++ b/Tests/RecordRegionShortcutCheck.sources
@@ -1,0 +1,1 @@
+Sources/Services/ShortcutService.swift

--- a/Tests/RecordRegionShortcutCheck.swift
+++ b/Tests/RecordRegionShortcutCheck.swift
@@ -47,6 +47,6 @@ struct RecordRegionShortcutCheck {
         let data = try JSONEncoder().encode(rebound)
         let decoded = try JSONDecoder().decode(ShortcutService.Shortcut.self, from: data)
         assert(decoded == rebound)
-        print("RecordRegionShortcutCheck: отдельная команда, безопасные значения по умолчанию и переназначение проверены")
+        print("RecordRegionShortcutCheck: separate action, safe defaults, and rebinding verified")
     }
 }

--- a/Tests/RecordRegionShortcutCheck.swift
+++ b/Tests/RecordRegionShortcutCheck.swift
@@ -1,0 +1,52 @@
+import AppKit
+import Foundation
+
+@MainActor
+enum ActiveDisplayResolver {
+    static func activeScreen(preferPointer: Bool) -> NSScreen? { nil }
+}
+
+@MainActor
+final class ScreenRecordingManager {
+    static let shared = ScreenRecordingManager()
+    var isActive = false
+}
+
+@MainActor
+final class RecordingBarPresenter {
+    static let shared = RecordingBarPresenter()
+    func togglePicker() {}
+}
+
+@MainActor
+enum RecordingCaptureEntry {
+    static func recordAreaOnActiveDisplay() async {}
+}
+
+@MainActor
+final class CaptureOrchestrator {
+    static let shared = CaptureOrchestrator()
+    func performCapture(_ action: ShortcutService.Action, on screen: NSScreen?) async {}
+}
+
+@main
+struct RecordRegionShortcutCheck {
+    @MainActor
+    static func main() throws {
+        let action = ShortcutService.Action.recordingArea
+        let shortcut = action.defaultShortcut!
+        assert(action.rawValue == 7)
+        assert(ShortcutService.Action.recording.rawValue == 6)
+        assert(!shortcut.enabled)
+        assert(shortcut.keyCode == ShortcutService.Shortcut.defaultRecording.keyCode)
+        assert(shortcut.modifiers != ShortcutService.Shortcut.defaultRecording.modifiers)
+        assert(Set(ShortcutService.Action.allCases.map(\.rawValue)).count == 7)
+        var rebound = shortcut
+        rebound.keyCode = 15
+        rebound.enabled = true
+        let data = try JSONEncoder().encode(rebound)
+        let decoded = try JSONDecoder().decode(ShortcutService.Shortcut.self, from: data)
+        assert(decoded == rebound)
+        print("RecordRegionShortcutCheck: отдельная команда, безопасные значения по умолчанию и переназначение проверены")
+    }
+}


### PR DESCRIPTION
Closes #135.

Add **Record Region** in Settings > Shortcuts to jump directly into area recording. The suggested binding is ⌥⇧⌘2, disabled by default and rebindable, so existing shortcuts keep their behavior. The command refreshes the source catalog, selects the display containing the pointer, hides the picker, and reuses the existing area-selection/countdown/recording flow.

Active recordings are left alone, including when one starts during the catalog refresh. A catalog failure or missing display shows an error instead of silently doing nothing. The recording bar shortcut remains unchanged.

Validation: all app sources type-check with the project settings and the real DockProgress dependency. `RecordRegionShortcutCheck` compiles the production shortcut service and checks the new action's stable ID, disabled default, distinct modifiers, and serialization of a custom binding; unrelated action destinations are stubbed and the event tap is not installed. Full release build is left to CI because Xcode is not installed locally.

Manual check still needed: enable/rebind Record Region, invoke it before opening the bar, select an area on each display, check countdown and Escape, then invoke the shortcut during an active recording and confirm it does not start another one.
