### PR TITLE
feat: expose capture actions through bettershot URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,6 +205,25 @@ Preferences are split across two enums: `AppPreferences` (`bs_` keys, the
 capture pipeline and history) and `BetterShotPreferences` (editor, preview,
 recording devices, teleprompter). Add to whichever the feature already reads from.
 
+### URL automation
+
+Raycast, Shortcuts, Alfred, and scripts can open `bettershot://` URLs. For example,
+`open 'bettershot://capture/region'` launches BetterShot if needed and starts the
+normal region-capture flow. Available routes:
+
+- `bettershot://capture/region`
+- `bettershot://capture/fullscreen`
+- `bettershot://capture/window`
+- `bettershot://record` (opens the recording picker; does not toggle it off)
+- `bettershot://ocr`
+- `bettershot://color-picker`
+- `bettershot://settings`
+
+Actions use the display containing the pointer and preserve capture preferences,
+timers, output locations, and permission checks. Startup URLs wait for app
+initialization. Unknown routes, credentials, ports, queries, and fragments are
+ignored. Recording requests are ignored while a recording is active.
+
 ### Menu bar
 
 `MenuBarPopoverController` creates a custom `NSPanel` (not `MenuBarExtra`) for

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -22,6 +22,17 @@
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
     <key>LSUIElement</key>
     <true/>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>com.bettershot.url</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>bettershot</string>
+            </array>
+        </dict>
+    </array>
     <key>NSInputMonitoringUsageDescription</key>
     <string>BetterShot records the shortcut keys you press during a recording, only when you turn on key capture, so the editor can show them on screen.</string>
     <key>NSCameraUsageDescription</key>

--- a/Sources/App/BetterShotDelegate.swift
+++ b/Sources/App/BetterShotDelegate.swift
@@ -4,6 +4,8 @@ import UserNotifications
 @MainActor
 final class BetterShotDelegate: NSObject, NSApplicationDelegate {
     private var permissionPollTimer: Timer?
+    private var didFinishLaunching = false
+    private var pendingURLActions: [CaptureURLAction] = []
 
     /// The notification delegate has to be in place before launch finishes,
     /// or the system handles clicks on export notifications itself and never
@@ -34,6 +36,41 @@ final class BetterShotDelegate: NSObject, NSApplicationDelegate {
         } else {
             ShortcutService.requestAccessibilityPermission()
             startPermissionPolling()
+        }
+        didFinishLaunching = true
+        performPendingURLActions()
+    }
+
+    func application(_ application: NSApplication, open urls: [URL]) {
+        pendingURLActions.append(contentsOf: urls.compactMap(CaptureURLAction.init(url:)))
+        if didFinishLaunching { performPendingURLActions() }
+    }
+
+    private func performPendingURLActions() {
+        let actions = pendingURLActions
+        pendingURLActions.removeAll()
+        guard !actions.isEmpty else { return }
+        let screen = ActiveDisplayResolver.activeScreen(preferPointer: true)
+        Task {
+            for action in actions {
+                switch action {
+                case .region:
+                    await CaptureOrchestrator.shared.performCapture(.region, on: screen)
+                case .fullscreen:
+                    await CaptureOrchestrator.shared.performCapture(.fullscreen, on: screen)
+                case .window:
+                    await CaptureOrchestrator.shared.performCapture(.window, on: screen)
+                case .ocr:
+                    await CaptureOrchestrator.shared.performCapture(.ocr, on: screen)
+                case .colorPicker:
+                    await CaptureOrchestrator.shared.performCapture(.colorPicker, on: screen)
+                case .recording:
+                    guard !ScreenRecordingManager.shared.isActive else { continue }
+                    RecordingBarPresenter.shared.showPicker(on: screen.flatMap { ActiveDisplayResolver.displayID(for: $0) })
+                case .settings:
+                    SettingsWindowController.shared.open(on: screen)
+                }
+            }
         }
     }
 

--- a/Sources/App/CaptureURLAction.swift
+++ b/Sources/App/CaptureURLAction.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+nonisolated enum CaptureURLAction: String, CaseIterable {
+    case region = "capture/region"
+    case fullscreen = "capture/fullscreen"
+    case window = "capture/window"
+    case recording = "record"
+    case ocr
+    case colorPicker = "color-picker"
+    case settings
+
+    init?(url: URL) {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              components.scheme?.lowercased() == "bettershot",
+              components.user == nil, components.password == nil, components.port == nil,
+              components.query == nil, components.fragment == nil,
+              let host = components.host else { return nil }
+        self.init(rawValue: host.lowercased() + components.path)
+    }
+}

--- a/Sources/BetterShot/RecordingBarPresenter.swift
+++ b/Sources/BetterShot/RecordingBarPresenter.swift
@@ -50,14 +50,14 @@ final class RecordingBarPresenter {
         }
     }
 
-    func showPicker() {
+    func showPicker(on displayID: CGDirectDisplayID? = nil) {
         let panel = panel ?? makePanel()
         PreviewWindowCaptureExclusion.shared.register(window: panel)
         Task {
             await RecordingSourceCatalog.shared.refresh()
         }
         mode = .picker
-        position(panel, displayID: ActiveDisplayResolver.activeDisplayID(preferPointer: false))
+        position(panel, displayID: displayID ?? ActiveDisplayResolver.activeDisplayID(preferPointer: false))
         panel.orderFrontRegardless()
         // The picker is driven from the keyboard too (Esc, A for the last
         // region), and key events only reach the panel while BetterShot is

--- a/Tests/CaptureURLActionCheck.sources
+++ b/Tests/CaptureURLActionCheck.sources
@@ -1,0 +1,1 @@
+Sources/App/CaptureURLAction.swift

--- a/Tests/CaptureURLActionCheck.swift
+++ b/Tests/CaptureURLActionCheck.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+@main
+struct CaptureURLActionCheck {
+    static func main() {
+        for action in CaptureURLAction.allCases {
+            assert(CaptureURLAction(url: URL(string: "bettershot://\(action.rawValue)")!) == action)
+        }
+        assert(CaptureURLAction(url: URL(string: "BETTERSHOT://CAPTURE/region")!) == .region)
+        for value in [
+            "https://capture/region", "bettershot:record", "bettershot:///record",
+            "bettershot://unknown", "bettershot://capture", "bettershot://capture/region/extra",
+            "bettershot://capture/region?output=/tmp/test.png", "bettershot://record#start",
+            "bettershot://user@record", "bettershot://user:password@record", "bettershot://record:123",
+            "bettershot://capture/../region", "bettershot://settings/anything"
+        ] {
+            assert(CaptureURLAction(url: URL(string: value)!) == nil, value)
+        }
+        print("CaptureURLActionCheck: команды URL и отклонение некорректных адресов проверены")
+    }
+}

--- a/Tests/CaptureURLActionCheck.swift
+++ b/Tests/CaptureURLActionCheck.swift
@@ -16,6 +16,6 @@ struct CaptureURLActionCheck {
         ] {
             assert(CaptureURLAction(url: URL(string: value)!) == nil, value)
         }
-        print("CaptureURLActionCheck: команды URL и отклонение некорректных адресов проверены")
+        print("CaptureURLActionCheck: URL routes and malformed URL rejection verified")
     }
 }


### PR DESCRIPTION
Closes #86.

Register the `bettershot` URL scheme and route the seven requested commands through the existing capture, recording-picker, and settings entry points. This lets Raycast, Shortcuts, Alfred, and `open 'bettershot://capture/region'` launch the app and use its normal capture preferences, timer, output location, and permission checks.

URLs received during startup wait until app initialization finishes. Commands use the display containing the pointer. `bettershot://record` opens the picker instead of toggling it closed, and is ignored while a recording is active. Unknown routes, URL credentials, ports, queries, and fragments are ignored. The supported routes are documented in CONTRIBUTING.md.

Validation: `CaptureURLActionCheck` compiles the production parser and covers every route plus malformed/unsupported URLs; Info.plist passes `plutil -lint`. All app sources type-check with the settings from project.yml and the real DockProgress dependency. No local Xcode installation; the release build runs in CI.

Manual check still needed: install the built app, invoke each URL from `open` both with the app running and after quitting it, and verify the target display, capture preferences, and active-recording guard. Invalid URLs should have no effect.
