### PR TITLE
fix: update existing exports when saving annotations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,13 @@ both call `AnnoShapeDrawing.draw(document, in:target:)`, so there is one drawing
 implementation to keep correct. `AnnotationRenderer` wraps that with the
 background, mockup effects, and watermark for the flattened image.
 
+**Save** (⌘S, including Save in the close prompt) commits editable annotations to
+history and updates the capture's associated export in place. If Export was used
+in this editor session, Save updates that chosen destination instead. Replacement
+is atomic and keeps the destination format. The untouched capture and editable
+base stay separate; images without an associated export remain history-only
+until the user chooses Export. Copy and Upload do not update the saved export.
+
 ### Recording studio
 
 `RecordingStudioModel` owns a `RecordingEditDocument` (clips, speed, transitions,

--- a/Sources/BetterShot/AnnotationEditorWindow.swift
+++ b/Sources/BetterShot/AnnotationEditorWindow.swift
@@ -714,7 +714,11 @@ struct AnnotationEditorWindow: View {
         }
 
         if updatingExport, let exportURL {
-            try ScreenshotFileActions.replaceExistingExport(from: resultURL, at: exportURL)
+            let compressionQuality = BetterShotPreferences.compressionQuality
+            try await Task.detached(priority: .userInitiated) {
+                try ScreenshotFileActions.replaceExistingExport(
+                    from: resultURL, at: exportURL, compressionQuality: compressionQuality)
+            }.value
         }
         model.markSaved()
         return resultURL

--- a/Sources/BetterShot/AnnotationEditorWindow.swift
+++ b/Sources/BetterShot/AnnotationEditorWindow.swift
@@ -30,6 +30,7 @@ struct AnnotationEditorWindow: View {
     @State private var isInspectorPresented = false
     @State private var isSaving = false
     @State private var isExporting = false
+    @State private var lastExportURL: URL?
     @State private var saveFlash = false
     @State private var isCopying = false
     @State private var copyFlash = false
@@ -87,6 +88,7 @@ struct AnnotationEditorWindow: View {
             }
             .task(id: url) {
                 clearInspectorFocus()
+                lastExportURL = nil
                 model.load(url: url, dismiss: dismissWindow)
             }
             .onAppear {
@@ -578,6 +580,7 @@ struct AnnotationEditorWindow: View {
                         destinationURL: destinationURL,
                         contentType: contentType
                     )
+                    lastExportURL = destinationURL
                 } catch {
                     model.errorMessage = "Failed to export image: \(error.localizedDescription)"
                 }
@@ -666,8 +669,9 @@ struct AnnotationEditorWindow: View {
     /// out of the editor - Done, Save, Upload, the close prompt - goes
     /// through it.
     @discardableResult
-    private func commitEdits() async throws -> URL? {
+    private func commitEdits(updatingExport: Bool = false) async throws -> URL? {
         guard let sourceURL = model.sourceURL else { return nil }
+        let exportURL = lastExportURL ?? HistoryStore.shared.annotationExportURL(for: sourceURL)
 
         let baseURL = model.baseImageURL ?? sourceURL
         let shapes = model.shapes
@@ -709,6 +713,9 @@ struct AnnotationEditorWindow: View {
             model.baseImageURL = resultURL
         }
 
+        if updatingExport, let exportURL {
+            try ScreenshotFileActions.replaceExistingExport(from: resultURL, at: exportURL)
+        }
         model.markSaved()
         return resultURL
     }
@@ -726,7 +733,7 @@ struct AnnotationEditorWindow: View {
             defer { isSaving = false }
             do {
                 guard let sourceURL = model.sourceURL,
-                      let resultURL = try await commitEdits() else { return }
+                      let resultURL = try await commitEdits(updatingExport: true) else { return }
                 _ = ScreenshotPreviewStack.shared.applyAnnotation(
                     originalURL: sourceURL,
                     historyURL: resultURL
@@ -758,7 +765,7 @@ struct AnnotationEditorWindow: View {
                 Task {
                     do {
                         if let sourceURL = model.sourceURL,
-                           let resultURL = try await commitEdits() {
+                           let resultURL = try await commitEdits(updatingExport: true) {
                             _ = ScreenshotPreviewStack.shared.applyAnnotation(
                                 originalURL: sourceURL,
                                 historyURL: resultURL

--- a/Sources/BetterShot/BetterShotPreferences.swift
+++ b/Sources/BetterShot/BetterShotPreferences.swift
@@ -320,7 +320,7 @@ enum ScreenshotFileActions {
             
             try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
         } else {
-            try exportImage(from: sourceURL, to: destinationURL, contentType: BetterShotPreferences.exportFormat.contentType)
+            try exportImage(from: sourceURL, to: destinationURL, contentType: BetterShotPreferences.exportFormat.contentType, compressionQuality: BetterShotPreferences.compressionQuality)
         }
     }
 
@@ -328,7 +328,7 @@ enum ScreenshotFileActions {
     /// The replacement is staged beside the destination and atomically swapped
     /// in only after encoding succeeds, so the last good export is never deleted
     /// first. Pixel dimensions are preserved; PNG-to-PNG updates copy bytes.
-    static func replaceExistingExport(from sourceURL: URL, at destinationURL: URL) throws {
+    nonisolated static func replaceExistingExport(from sourceURL: URL, at destinationURL: URL, compressionQuality: Double) throws {
         guard let destinationType = exportContentType(for: destinationURL) else {
             throw CocoaError(.fileWriteUnknown)
         }
@@ -341,7 +341,7 @@ enum ScreenshotFileActions {
         if destinationType == .png, actualImageContentType(at: sourceURL) == .png {
             try FileManager.default.copyItem(at: sourceURL, to: stagingURL)
         } else {
-            try exportImage(from: sourceURL, to: stagingURL, contentType: destinationType)
+            try exportImage(from: sourceURL, to: stagingURL, contentType: destinationType, compressionQuality: compressionQuality)
         }
 
         if FileManager.default.fileExists(atPath: destinationURL.path) {
@@ -362,7 +362,7 @@ enum ScreenshotFileActions {
         BetterShotPreferences.exportFormat.contentType
     }
     
-    private static func exportImage(from sourceURL: URL, to destinationURL: URL, contentType: UTType) throws {
+    nonisolated private static func exportImage(from sourceURL: URL, to destinationURL: URL, contentType: UTType, compressionQuality: Double) throws {
         if FileManager.default.fileExists(atPath: destinationURL.path) {
             try FileManager.default.removeItem(at: destinationURL)
         }
@@ -384,7 +384,7 @@ enum ScreenshotFileActions {
         }
         
         let options: [CFString: Any] = contentType == .png ? [:] : [
-            kCGImageDestinationLossyCompressionQuality: BetterShotPreferences.compressionQuality
+            kCGImageDestinationLossyCompressionQuality: compressionQuality
         ]
         
         CGImageDestinationAddImageFromSource(destination, source, 0, options as CFDictionary)
@@ -394,7 +394,7 @@ enum ScreenshotFileActions {
         }
     }
 
-    private static func exportContentType(for url: URL) -> UTType? {
+    nonisolated private static func exportContentType(for url: URL) -> UTType? {
         guard let type = UTType(filenameExtension: url.pathExtension) else { return nil }
         if type.conforms(to: .png) { return .png }
         if type.conforms(to: .jpeg) { return .jpeg }
@@ -402,7 +402,7 @@ enum ScreenshotFileActions {
         return nil
     }
 
-    private static func actualImageContentType(at url: URL) -> UTType? {
+    nonisolated private static func actualImageContentType(at url: URL) -> UTType? {
         guard let source = CGImageSourceCreateWithURL(
             url as CFURL,
             [kCGImageSourceShouldCache: false] as CFDictionary

--- a/Sources/History/HistoryStore.swift
+++ b/Sources/History/HistoryStore.swift
@@ -120,6 +120,14 @@ final class HistoryStore {
 
     // MARK: - Access
 
+    func annotationExportURL(for url: URL) -> URL? {
+        guard let record = record(matching: url), record.kind == .screenshot,
+              let path = record.beautifiedPath else { return nil }
+        let exportURL = URL(fileURLWithPath: path).standardizedFileURL
+        guard exportURL != urlForRecord(record).standardizedFileURL else { return nil }
+        return exportURL
+    }
+
     func urlForRecord(_ record: CaptureRecord) -> URL {
         if let sourcePath = record.sourcePath {
             return URL(fileURLWithPath: sourcePath)

--- a/Tests/ExportIntegration.swift
+++ b/Tests/ExportIntegration.swift
@@ -30,6 +30,7 @@ struct ExportIntegration {
         CGImageDestinationAddImage(destination, image, nil)
         precondition(CGImageDestinationFinalize(destination))
         try await checkCaptureStorage(image: image, source: source, directory: directory)
+        try checkAnnotationExport(image: image, source: source, directory: directory)
         let exported = directory.appendingPathComponent("export.png")
         let start = Date()
         try AnnotationRenderer.render(
@@ -249,6 +250,35 @@ struct ExportIntegration {
         await writer.finishWriting()
         precondition(writer.status == .completed)
     }
+}
+
+@MainActor
+private func checkAnnotationExport(image: CGImage, source: URL, directory: URL) throws {
+    let history = HistoryStore(storageDirectory: directory.appendingPathComponent("annotation-history"))
+    let record = history.importCapture(from: source, deleteSource: false)!
+    let raw = history.urlForRecord(record)
+    let rawData = try Data(contentsOf: raw)
+    precondition(history.annotationExportURL(for: raw) == nil)
+    let output = directory.appendingPathComponent("annotation-export.png")
+    try FileManager.default.copyItem(at: source, to: output)
+    precondition(history.setBeautifiedPath(output.path, for: record.id))
+    precondition(history.annotationExportURL(for: raw) == output)
+    precondition(history.annotationExportURL(for: output) == output)
+    precondition(history.annotationExportURL(for: source) == nil)
+    let edited = CaptureOrchestrator.saveImage(
+        image.cropping(to: CGRect(x: 0, y: 0, width: 32, height: 32))!, in: directory.path)!
+    try ScreenshotFileActions.replaceExistingExport(from: edited, at: history.annotationExportURL(for: raw)!)
+    let savedData = try Data(contentsOf: output)
+    precondition(savedData != rawData)
+    precondition((try? Data(contentsOf: raw)) == rawData)
+    do {
+        try ScreenshotFileActions.replaceExistingExport(
+            from: directory.appendingPathComponent("missing.png"), at: output)
+        preconditionFailure("Ожидалась ошибка чтения исходника")
+    } catch {}
+    precondition((try? Data(contentsOf: output)) == savedData)
+    precondition(history.records.count == 1)
+    print("PASS сохранение аннотаций обновляет связанный экспорт и сохраняет исходник при ошибке")
 }
 
 /// Exercises production persistence in an isolated directory; never alters the user's captures.

--- a/Tests/ExportIntegration.swift
+++ b/Tests/ExportIntegration.swift
@@ -274,11 +274,11 @@ private func checkAnnotationExport(image: CGImage, source: URL, directory: URL) 
     do {
         try ScreenshotFileActions.replaceExistingExport(
             from: directory.appendingPathComponent("missing.png"), at: output)
-        preconditionFailure("Ожидалась ошибка чтения исходника")
+        preconditionFailure("Expected reading the source to fail")
     } catch {}
     precondition((try? Data(contentsOf: output)) == savedData)
     precondition(history.records.count == 1)
-    print("PASS сохранение аннотаций обновляет связанный экспорт и сохраняет исходник при ошибке")
+    print("PASS annotation saves update the associated export and preserve the source and previous export on failure")
 }
 
 /// Exercises production persistence in an isolated directory; never alters the user's captures.

--- a/Tests/ExportIntegration.swift
+++ b/Tests/ExportIntegration.swift
@@ -30,7 +30,7 @@ struct ExportIntegration {
         CGImageDestinationAddImage(destination, image, nil)
         precondition(CGImageDestinationFinalize(destination))
         try await checkCaptureStorage(image: image, source: source, directory: directory)
-        try checkAnnotationExport(image: image, source: source, directory: directory)
+        try await checkAnnotationExport(image: image, source: source, directory: directory)
         let exported = directory.appendingPathComponent("export.png")
         let start = Date()
         try AnnotationRenderer.render(
@@ -253,7 +253,7 @@ struct ExportIntegration {
 }
 
 @MainActor
-private func checkAnnotationExport(image: CGImage, source: URL, directory: URL) throws {
+private func checkAnnotationExport(image: CGImage, source: URL, directory: URL) async throws {
     let history = HistoryStore(storageDirectory: directory.appendingPathComponent("annotation-history"))
     let record = history.importCapture(from: source, deleteSource: false)!
     let raw = history.urlForRecord(record)
@@ -267,16 +267,26 @@ private func checkAnnotationExport(image: CGImage, source: URL, directory: URL) 
     precondition(history.annotationExportURL(for: source) == nil)
     let edited = CaptureOrchestrator.saveImage(
         image.cropping(to: CGRect(x: 0, y: 0, width: 32, height: 32))!, in: directory.path)!
-    try ScreenshotFileActions.replaceExistingExport(from: edited, at: history.annotationExportURL(for: raw)!)
+    try ScreenshotFileActions.replaceExistingExport(from: edited, at: history.annotationExportURL(for: raw)!, compressionQuality: 0.9)
     let savedData = try Data(contentsOf: output)
     precondition(savedData != rawData)
     precondition((try? Data(contentsOf: raw)) == rawData)
     do {
         try ScreenshotFileActions.replaceExistingExport(
-            from: directory.appendingPathComponent("missing.png"), at: output)
+            from: directory.appendingPathComponent("missing.png"), at: output, compressionQuality: 0.9)
         preconditionFailure("Expected reading the source to fail")
     } catch {}
     precondition((try? Data(contentsOf: output)) == savedData)
+    for type in [UTType.jpeg, .heic] {
+        let encoded = directory.appendingPathComponent("annotation-export.\(type.preferredFilenameExtension!)")
+        try await Task.detached {
+            try ScreenshotFileActions.replaceExistingExport(from: edited, at: encoded, compressionQuality: 0.9)
+        }.value
+        let encodedSource = CGImageSourceCreateWithURL(encoded as CFURL, nil)!
+        precondition(CGImageSourceGetType(encodedSource) as String? == type.identifier)
+        let decoded = CGImageSourceCreateImageAtIndex(encodedSource, 0, nil)!
+        precondition(decoded.width == 32 && decoded.height == 32)
+    }
     precondition(history.records.count == 1)
     print("PASS annotation saves update the associated export and preserve the source and previous export on failure")
 }


### PR DESCRIPTION
Closes #127.

Save (⌘S and Save in the close prompt) now commits the editable annotation document and updates the capture's associated export in place. After using Export in the current editor session, subsequent saves update that chosen destination. Previously, Save only updated the internal history copy, leaving the visible file in the save folder unchanged.

The destination comes from the capture's existing `beautifiedPath` mapping or an explicit Export selection, never from an arbitrary source image. The raw capture and editable base remain untouched. Replacement uses the existing atomic export helper, preserves the destination format, and performs file work and JPEG/HEIC encoding off the main actor using a snapshot of the compression preference. If replacement fails, the editor reports the error before marking the document saved. Images without an associated export keep the existing history-only behavior until Export is chosen; Copy and Upload do not overwrite an export.

Validation: all app sources type-check with the project settings and real DockProgress dependency. Also compiled the production app code as a testable library using Command Line Tools and ran the new `checkAnnotationExport` integration check from Tests/ExportIntegration.swift against it: associated-path lookup, changed output, unchanged raw pixels, unknown-source exclusion, failure preserving the previous export, no duplicate history record, and detached JPEG/HEIC encoding with preserved format and dimensions all pass. The integration check needed to run outside the local sandbox for macOS's atomic file replacement API. The normal Xcode release build runs in CI.

Manual UI check still needed: annotate a captured screenshot and press ⌘S; verify the existing file changes. Save more edits, reopen from History, clear annotations, and save again. Export to a different path and check that the next Save updates it. Make the destination unwritable and confirm Save reports failure and the document remains unsaved.
