### PR TITLE
fix: save finished recordings to the configured folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,13 @@ User presses ⌘⇧2 → RecordingPickerBar (screen / window / area / screenshot
 
 ### Storage
 
+The recording preview card's **Save** and **Save All** render a flattened video
+with its cursor, camera, and current edits into the configured save folder.
+The card stays available if saving fails. Settings > Recording > **Save recordings
+to the save folder** enables the same export after stopping; it is off by default
+so stopping a long recording need not start an export. The recording project and
+source tracks remain in Application Support in either mode.
+
 Everything lives under `~/Library/Application Support/BetterShot/`:
 
 - Screenshots keep their untouched original there (`CaptureRecord.filename`);

--- a/Sources/App/BetterShotApp.swift
+++ b/Sources/App/BetterShotApp.swift
@@ -40,7 +40,8 @@ struct BetterShotApp: App {
             openWindow(id: "VIDEO_EDITOR", value: directoryURL)
         }
 
-        ScreenRecordingManager.shared.onFinishRecording = { session, _ in
+        ScreenRecordingManager.shared.onFinishRecording = { session, displayID in
+            let saveToFolder = AfterCaptureActions.isEnabled(.save, for: .recording)
             Task { @MainActor in
                 let historyURL = await ScreenshotHistoryStore.shared.importRecordingSession(session)
                 RecordingProjectStore.shared.reload()
@@ -48,6 +49,19 @@ struct BetterShotApp: App {
                     PreviewPanelPresenter.shared.onEditVideo?(historyURL)
                 } else {
                     PreviewOverlay.shared.show(url: historyURL)
+                }
+                if saveToFolder {
+                    do {
+                        _ = try await RecordingDeliverable.saveToDefaultLocation(for: historyURL)
+                        ToastWindow.shared.show(message: "Recording saved!", on: ActiveDisplayResolver.screen(for: displayID))
+                    } catch {
+                        ToastWindow.shared.show(
+                            title: "Couldn't save recording",
+                            message: error.localizedDescription,
+                            systemIcon: "exclamationmark.triangle",
+                            on: ActiveDisplayResolver.screen(for: displayID)
+                        )
+                    }
                 }
             }
         }

--- a/Sources/BetterShot/RecordingDeliverable.swift
+++ b/Sources/BetterShot/RecordingDeliverable.swift
@@ -14,6 +14,20 @@ import Foundation
 
 @MainActor
 enum RecordingDeliverable {
+    private static var saveTasks: [URL: Task<URL, Error>] = [:]
+
+    static func saveToDefaultLocation(for mediaURL: URL) async throws -> URL {
+        let key = (session(for: mediaURL)?.directoryURL ?? mediaURL).standardizedFileURL
+        if let task = saveTasks[key] { return try await task.value }
+        let task = Task {
+            let deliverable = try await resolve(for: mediaURL)
+            return try await VideoFileActions.saveToDefaultLocation(from: deliverable)
+        }
+        saveTasks[key] = task
+        defer { saveTasks.removeValue(forKey: key) }
+        return try await task.value
+    }
+
     /// The session a recording media URL belongs to, if any. Bare movies
     /// opened from disk have none and are already their own deliverable.
     static func session(for mediaURL: URL) -> RecordingSession? {

--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -81,7 +81,13 @@ final class PreviewOverlay {
     }
 
     func saveAll() {
+        let staged = items.filter { !Self.isVideo($0) && DeckStaging.isStaged($0) }
+        staged.forEach {
+            DeckStaging.promote($0)
+            remove($0)
+        }
         items.forEach(save)
+        showSavedToast(count: staged.count)
     }
 
     func save(_ url: URL) {
@@ -98,7 +104,7 @@ final class PreviewOverlay {
                     ToastWindow.shared.show(message: "Recording saved!", on: screen)
                 } catch {
                     ToastWindow.shared.show(
-                        title: "Save Failed",
+                        title: "Couldn't save recording",
                         message: error.localizedDescription,
                         systemIcon: "exclamationmark.triangle",
                         on: screen

--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -100,6 +100,7 @@ final class PreviewOverlay {
                 defer { savingItems.remove(url) }
                 do {
                     _ = try await RecordingDeliverable.saveToDefaultLocation(for: url)
+                    guard items.contains(url) else { return }
                     remove(url)
                     ToastWindow.shared.show(message: "Recording saved!", on: screen)
                 } catch {

--- a/Sources/Preview/PreviewOverlay.swift
+++ b/Sources/Preview/PreviewOverlay.swift
@@ -12,6 +12,7 @@ final class PreviewOverlay {
     private static let clearAllHeight: CGFloat = 26
 
     private(set) var items: [URL] = []
+    private(set) var savingItems: Set<URL> = []
     private var panel: NSPanel?
     private var dismissTasks: [URL: Task<Void, Never>] = [:]
     private var targetScreen: NSScreen?
@@ -80,13 +81,32 @@ final class PreviewOverlay {
     }
 
     func saveAll() {
-        let staged = items.filter(DeckStaging.isStaged)
-        staged.forEach { DeckStaging.promote($0) }
-        clearAll()
-        showSavedToast(count: staged.count)
+        items.forEach(save)
     }
 
     func save(_ url: URL) {
+        guard !savingItems.contains(url) else { return }
+        if Self.isVideo(url) {
+            savingItems.insert(url)
+            cancelScheduledDismiss(for: url)
+            let screen = targetScreen
+            Task {
+                defer { savingItems.remove(url) }
+                do {
+                    _ = try await RecordingDeliverable.saveToDefaultLocation(for: url)
+                    remove(url)
+                    ToastWindow.shared.show(message: "Recording saved!", on: screen)
+                } catch {
+                    ToastWindow.shared.show(
+                        title: "Save Failed",
+                        message: error.localizedDescription,
+                        systemIcon: "exclamationmark.triangle",
+                        on: screen
+                    )
+                }
+            }
+            return
+        }
         if DeckStaging.isStaged(url) {
             DeckStaging.promote(url)
             showSavedToast(count: 1)
@@ -94,7 +114,12 @@ final class PreviewOverlay {
         remove(url)
     }
 
-    var hasStagedItems: Bool { items.contains(where: DeckStaging.isStaged) }
+    var hasSavableItems: Bool { items.contains { DeckStaging.isStaged($0) || Self.isVideo($0) } }
+
+    static func isVideo(_ url: URL) -> Bool {
+        let ext = url.pathExtension.lowercased()
+        return ext == "mov" || ext == "mp4"
+    }
 
     private func showSavedToast(count: Int) {
         guard count > 0 else { return }
@@ -185,7 +210,7 @@ struct PreviewDeckView: View {
         VStack(alignment: pinnedLeft ? .leading : .trailing, spacing: 10) {
             if overlay.items.count > 1 {
                 HStack(spacing: 6) {
-                    if overlay.hasStagedItems {
+                    if overlay.hasSavableItems {
                         deckButton("Save All") { overlay.saveAll() }
                     }
                     deckButton("Clear All") { overlay.clearAll() }
@@ -226,12 +251,7 @@ struct PreviewCardView: View {
     private var cardSize: CGSize { AppPreferences.overlayCardSize.thumbnailSize }
     private var controlScale: CGFloat { AppPreferences.overlayCardSize.controlScale }
 
-    private var isVideo: Bool { Self.isVideo(url) }
-
-    private static func isVideo(_ url: URL) -> Bool {
-        let ext = url.pathExtension.lowercased()
-        return ext == "mov" || ext == "mp4"
-    }
+    private var isVideo: Bool { PreviewOverlay.isVideo(url) }
 
     var body: some View {
         Group {
@@ -300,6 +320,16 @@ struct PreviewCardView: View {
             }
         }
         .task(id: url) { await loadThumbnail() }
+        .disabled(overlay.savingItems.contains(url))
+        .allowsHitTesting(!overlay.savingItems.contains(url))
+        .overlay {
+            if overlay.savingItems.contains(url) {
+                ProgressView("Saving…")
+                    .controlSize(.small)
+                    .padding(8)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+            }
+        }
     }
 
     private func loadThumbnail() async {
@@ -309,7 +339,7 @@ struct PreviewCardView: View {
         // finished rendering the capture.
         let source = HistoryStore.ThumbnailSource(
             url: url,
-            kind: Self.isVideo(url) ? .recording : .screenshot
+            kind: PreviewOverlay.isVideo(url) ? .recording : .screenshot
         )
         let sampleSize = max(cardSize.width, cardSize.height) * 2 // retina headroom at the current card size
         isLoadingThumbnail = true
@@ -372,7 +402,7 @@ struct PreviewCardView: View {
                 pillButton("Copy") {
                     // Copy the capture itself, not the card's thumbnail.
                     do {
-                        if Self.isVideo(url) {
+                        if PreviewOverlay.isVideo(url) {
                             try VideoFileActions.copyToClipboard(from: url)
                         } else {
                             try ScreenshotFileActions.copyImageToClipboard(from: url)

--- a/Sources/Settings/PreferencesView.swift
+++ b/Sources/Settings/PreferencesView.swift
@@ -740,6 +740,7 @@ struct CaptureSettingsTab: View {
 // MARK: - Recording Settings
 
 struct RecordingSettingsTab: View {
+    @AppStorage(AfterCaptureAction.save.storageKey(for: .recording)) private var saveToFolder = false
     @AppStorage(BetterShotPreferences.recordingCameraDeviceIDKey) private var cameraID: String = ""
     @AppStorage(BetterShotPreferences.recordingMicrophoneDeviceIDKey) private var microphoneID: String = ""
     @AppStorage(BetterShotPreferences.recordingSystemAudioKey) private var captureAudio: Bool = false
@@ -814,6 +815,10 @@ struct RecordingSettingsTab: View {
                     Text("Open the editor when I stop")
                     Text("Off, you get a preview card and can open the editor from there.")
                 }
+                Toggle(isOn: $saveToFolder) {
+                    Text("Save recordings to the save folder")
+                    Text("Renders a video with the cursor and camera after recording. Longer recordings may take a while.")
+                }
             } header: {
                 Text("After Recording")
             }
@@ -851,6 +856,7 @@ struct RecordingSettingsTab: View {
                 startDelaySeconds = 0
                 teleprompterEnabled = false
                 openEditor = false
+                saveToFolder = false
                 exportSettings = VideoCompressionSettings()
                 RecordingExportPreferences.lastSettings = exportSettings
             }

--- a/Tests/RecordingSaveCheck.sources
+++ b/Tests/RecordingSaveCheck.sources
@@ -1,0 +1,1 @@
+Sources/BetterShot/RecordingDeliverable.swift

--- a/Tests/RecordingSaveCheck.swift
+++ b/Tests/RecordingSaveCheck.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+struct RecordingSession {
+    let directoryURL: URL
+    static func isSessionDirectory(_ url: URL) -> Bool { url.pathExtension == "bettershotrec" }
+    func effectiveEditDocument() -> Int? { nil }
+    func freshFinalURL(matching document: Int?) -> URL? { nil }
+}
+
+@MainActor
+enum RecordingSessionRenderer {
+    static var calls = 0
+    static var shouldFail = false
+    static func ensureDeliverable(
+        for session: RecordingSession,
+        progress: (Double) -> Void = { _ in }
+    ) async throws -> URL {
+        calls += 1
+        try await Task.sleep(for: .milliseconds(10))
+        if shouldFail { throw CocoaError(.fileReadCorruptFile) }
+        progress(1)
+        return session.directoryURL.appendingPathComponent("final.mp4")
+    }
+}
+
+@MainActor
+final class DockExportProgressCoordinator {
+    static let shared = DockExportProgressCoordinator()
+    func start() -> UUID { UUID() }
+    func finish(_ id: UUID) {}
+    func update(_ id: UUID, progress: Double) {}
+}
+
+@MainActor
+enum VideoFileActions {
+    static var directory = FileManager.default.temporaryDirectory
+    static var calls = 0
+    static func saveToDefaultLocation(from source: URL) async throws -> URL {
+        calls += 1
+        let destination = directory.appendingPathComponent("saved-\(calls).mp4")
+        try FileManager.default.copyItem(at: source, to: destination)
+        return destination
+    }
+}
+
+@main
+struct RecordingSaveCheck {
+    @MainActor
+    static func main() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let session = root.appendingPathComponent("Test.bettershotrec")
+        try FileManager.default.createDirectory(at: session, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        VideoFileActions.directory = root
+        let raw = session.appendingPathComponent("screen.mov")
+        let final = session.appendingPathComponent("final.mp4")
+        try Data("raw".utf8).write(to: raw)
+        try Data("flattened".utf8).write(to: final)
+        async let automatic = RecordingDeliverable.saveToDefaultLocation(for: raw)
+        async let manual = RecordingDeliverable.saveToDefaultLocation(for: final)
+        let (first, second) = try await (automatic, manual)
+        assert(first == second)
+        assert(RecordingSessionRenderer.calls == 1 && VideoFileActions.calls == 1)
+        assert((try? Data(contentsOf: first)) == Data("flattened".utf8))
+        assert((try? Data(contentsOf: raw)) == Data("raw".utf8))
+        RecordingSessionRenderer.shouldFail = true
+        do {
+            _ = try await RecordingDeliverable.saveToDefaultLocation(for: raw)
+            assertionFailure("Expected rendering to fail")
+        } catch {}
+        assert(VideoFileActions.calls == 1)
+        RecordingSessionRenderer.shouldFail = false
+        _ = try await RecordingDeliverable.saveToDefaultLocation(for: raw)
+        assert(VideoFileActions.calls == 2)
+        let standalone = root.appendingPathComponent("standalone.mp4")
+        try Data("standalone".utf8).write(to: standalone)
+        let copied = try await RecordingDeliverable.saveToDefaultLocation(for: standalone)
+        assert((try? Data(contentsOf: copied)) == Data("standalone".utf8))
+        print("RecordingSaveCheck: flattened output, concurrent saves, failure retry, and source preservation verified")
+    }
+}


### PR DESCRIPTION
Closes #136.

The recording card's Save action only promoted staged screenshots, so a recording was dismissed without being written to the configured save folder. Save and Save All now resolve the recording's flattened deliverable and save it through the existing video export/remux helper. This includes cursor, camera, and current edits rather than handing out the raw screen track. Saving shows progress, prevents duplicate card actions, and leaves the card available with an error if export fails.

Settings > Recording also exposes **Save recordings to the save folder**, using the existing recording after-capture preference. It is off by default to preserve immediate Stop/preview behavior for long recordings; enabling it saves the finished video in the background after recording. The project and source tracks remain in Application Support. Simultaneous automatic and manual saves for the same session share one in-flight export.

Validation: all app sources type-check with the project settings and the real DockProgress dependency. `RecordingSaveCheck` compiles the production delivery/save coordinator with renderer and file-action stand-ins, checking flattened-output selection, concurrent-save sharing, retry after failure, standalone movies, and source preservation. It does not exercise real video encoding. Full release build is left to CI because local Xcode is unavailable.

Manual check still needed: record with cursor/camera/audio, use Save, and inspect the video in the configured folder. Repeat with Save All and with automatic saving enabled. Check that an unwritable folder reports an error and permits retry, and that recording projects remain editable.
